### PR TITLE
Fix: Force English fallback for unsupported locales

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,16 @@ class _QuizApplicationState extends State<QuizApplication> {
       themeMode: ThemeMode.system,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
+      localeResolutionCallback: (locale, supportedLocales) {
+        if (locale != null) {
+          for (final supportedLocale in supportedLocales) {
+            if (supportedLocale.languageCode == locale.languageCode) {
+              return supportedLocale;
+            }
+          }
+        }
+        return const Locale('en');
+      },
       showSemanticsDebugger: false,
       debugShowCheckedModeBanner: false,
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -803,5 +803,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.1 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.35.0"


### PR DESCRIPTION
Fixes #35.

This PR implements a `localeResolutionCallback` in `MaterialApp`.
It ensures that if the device locale is not explicitly supported, the app falls back to English instead of the first supported locale (which was Arabic, causing RTL issues for users with unsupported languages like Greek).

Logic:
- Checks if the device locale matches any supported locale.
- If match found: Use it.
- If no match found (or locale is null): Return explicit English locale.