### PR TITLE
refactor: Remove unused web logic from mobile/desktop file service

### DIFF
--- a/lib/data/services/file_service/mobile_desktop_file_service.dart
+++ b/lib/data/services/file_service/mobile_desktop_file_service.dart
@@ -103,20 +103,8 @@ class QuizFileService implements IFileService {
     if (result != null) {
       final platformFile = result.files.first;
 
-      if (PlatformDetail.isWeb) {
-        // Handle web platform
-        if (platformFile.bytes != null) {
-          final content = String.fromCharCodes(platformFile.bytes!);
-          final json = jsonDecode(content) as Map<String, dynamic>;
-          final quizFile = QuizFile.fromJson(json, filePath: platformFile.name);
-          originalFile = quizFile.deepCopy();
-          return quizFile;
-        }
-      } else {
-        // Handle desktop/mobile platforms
-        if (platformFile.path != null) {
-          return await readQuizFile(platformFile.path!);
-        }
+      if (platformFile.path != null) {
+        return await readQuizFile(platformFile.path!);
       }
     }
     return null;


### PR DESCRIPTION
This PR removes dead code related to web platform handling from the mobile/desktop file service implementation. This logic is already handled by the dedicated web file service.