### PR TITLE
Fix redundant navigation on file drop

### DIFF
--- a/lib/core/context_extension.dart
+++ b/lib/core/context_extension.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 extension SnackbarExtension on BuildContext {
   /// Displays a snack bar with the given text message.
@@ -16,5 +17,14 @@ extension SnackbarExtension on BuildContext {
   /// ```
   void presentSnackBar(String text) {
     ScaffoldMessenger.of(this).showSnackBar(SnackBar(content: Text(text)));
+  }
+}
+
+extension NavigationExtension on BuildContext {
+  /// Returns the current route location from GoRouter.
+  String get currentRoute {
+    return GoRouter.of(
+      this,
+    ).routerDelegate.currentConfiguration.matches.last.matchedLocation;
   }
 }

--- a/lib/presentation/screens/file_loaded_screen.dart
+++ b/lib/presentation/screens/file_loaded_screen.dart
@@ -432,15 +432,8 @@ class _FileLoadedScreenState extends State<FileLoadedScreen> {
             onDragDone: (details) {
               // Handle file drop for importing questions
               if (details.files.isNotEmpty) {
-                final currentRoute = GoRouter.of(context)
-                    .routerDelegate
-                    .currentConfiguration
-                    .matches
-                    .last
-                    .matchedLocation;
-
                 // If we are not on the file loaded screen, ignore the drop
-                if (currentRoute != AppRoutes.fileLoadedScreen) {
+                if (context.currentRoute != AppRoutes.fileLoadedScreen) {
                   return;
                 }
                 final firstFile = details.files.first;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -171,16 +171,8 @@ class _HomeScreenState extends State<HomeScreen> {
                 onDragDone: (details) {
                   // Validate that we have files
                   if (details.files.isNotEmpty && !_isLoading) {
-                    final currentRoute = GoRouter.of(context)
-                        .routerDelegate
-                        .currentConfiguration
-                        .matches
-                        .last
-                        .matchedLocation;
-
-                    // If we are already on the file loaded screen, ignore the drop in HomeScreen
-                    // FileLoadedScreen has its own DropTarget which will handle it
-                    if (currentRoute != AppRoutes.home) {
+                    // If we are not on the home screen, ignore the drop in HomeScreen
+                    if (context.currentRoute != AppRoutes.home) {
                       return;
                     }
 


### PR DESCRIPTION
This PR fixes a legacy issue where dropping a file would cause redundant navigation or incorrect state if the app was already on the FileLoadedScreen. It ensures that drops are handled by the active screen only.