### PR TITLE
Refine AI Error Dialog: Use localized title and raw exception message

### DIFF
--- a/lib/core/l10n/app_ar.arb
+++ b/lib/core/l10n/app_ar.arb
@@ -1150,15 +1150,9 @@
   "@aiGenerationFailed": {
     "description": "Message shown when AI question generation fails."
   },
-  "aiGenerationError": "خطأ في إنتاج الأسئلة: {error}",
-  "@aiGenerationError": {
-    "description": "Error message when generating questions with AI.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "API key invalid"
-      }
-    }
+  "aiGenerationErrorTitle": "خطأ في إنتاج الأسئلة",
+  "@aiGenerationErrorTitle": {
+    "description": "عنوان لمربع حوار الخطأ عند إنشاء الأسئلة باستخدام الذكاء الاصطناعي."
   },
   "noQuestionsInFile": "لم توجد أسئلة في الملف المستورد",
   "@noQuestionsInFile": {

--- a/lib/core/l10n/app_ca.arb
+++ b/lib/core/l10n/app_ca.arb
@@ -1142,15 +1142,9 @@
   "@aiGenerationFailed": {
     "description": "Missatge mostrat quan la generació de preguntes IA falla."
   },
-  "aiGenerationError": "Error en generar preguntes: {error}",
-  "@aiGenerationError": {
-    "description": "Missatge d'error en generar preguntes amb IA.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "Clau API no vàlida"
-      }
-    }
+  "aiGenerationErrorTitle": "Error en generar preguntes",
+  "@aiGenerationErrorTitle": {
+    "description": "Títol per al diàleg d'error en generar preguntes amb IA."
   },
   "noQuestionsInFile": "Cap pregunta trobada al fitxer importat",
   "@noQuestionsInFile": {

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -1138,15 +1138,10 @@
   "@aiGenerationFailed": {
     "description": "Nachricht, die angezeigt wird, wenn die KI-Fragengenerierung fehlschlägt."
   },
-  "aiGenerationError": "Fehler beim Generieren von Fragen: {error}",
-  "@aiGenerationError": {
-    "description": "Fehlermeldung beim Generieren von Fragen mit KI.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "API-Schlüssel ungültig"
-      }
-    }
+
+  "aiGenerationErrorTitle": "Fehler beim Generieren von Fragen",
+  "@aiGenerationErrorTitle": {
+    "description": "Titel für den Fehlerdialog beim Generieren von Fragen mit KI."
   },
   "noQuestionsInFile": "Keine Fragen in der importierten Datei gefunden",
   "@noQuestionsInFile": {

--- a/lib/core/l10n/app_el.arb
+++ b/lib/core/l10n/app_el.arb
@@ -248,7 +248,11 @@
   "aiGeneratedQuestions": "Δημιουργήθηκε από AI",
   "aiApiKeyRequired": "Παρακαλώ ρυθμίστε τουλάχιστον ένα κλειδί API AI στις Ρυθμίσεις για να χρησιμοποιήσετε τη δημιουργία AI.",
   "aiGenerationFailed": "Αδυναμία δημιουργίας ερωτήσεων. Δοκιμάστε με διαφορετικό περιεχόμενο.",
-  "aiGenerationError": "Σφάλμα δημιουργίας ερωτήσεων: {error}",
+
+  "aiGenerationErrorTitle": "Σφάλμα δημιουργίας ερωτήσεων",
+  "@aiGenerationErrorTitle": {
+    "description": "Τίτλος για το παράθυρο διαλόγου σφάλματος κατά τη δημιουργία ερωτήσεων με AI."
+  },
   "noQuestionsInFile": "Δεν βρέθηκαν ερωτήσεις στο εισαγόμενο αρχείο",
   "couldNotAccessFile": "Αδυναμία πρόσβασης στο επιλεγμένο αρχείο",
   "defaultOutputFileName": "output-file.quiz",

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -1168,16 +1168,12 @@
   "@aiGenerationFailed": {
     "description": "Message shown when AI question generation fails."
   },
-  "aiGenerationError": "Error generating questions: {error}",
-  "@aiGenerationError": {
-    "description": "Error message when generating questions with AI.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "API key invalid"
-      }
-    }
+
+  "aiGenerationErrorTitle": "Error generating questions",
+  "@aiGenerationErrorTitle": {
+    "description": "Title for the error dialog when generating questions with AI."
   },
+
   "noQuestionsInFile": "No questions found in the imported file",
   "@noQuestionsInFile": {
     "description": "Message shown when an imported file contains no questions."

--- a/lib/core/l10n/app_es.arb
+++ b/lib/core/l10n/app_es.arb
@@ -1115,16 +1115,12 @@
   "@aiGenerationFailed": {
     "description": "Mensaje mostrado cuando la generación de preguntas con IA falla."
   },
-  "aiGenerationError": "Error al generar preguntas: {error}",
-  "@aiGenerationError": {
-    "description": "Mensaje de error al generar preguntas con IA.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "API key invalid"
-      }
-    }
+
+  "aiGenerationErrorTitle": "Error al generar preguntas",
+  "@aiGenerationErrorTitle": {
+    "description": "Título para el diálogo de error al generar preguntas con IA."
   },
+
   "noQuestionsInFile": "No se encontraron preguntas en el archivo importado",
   "@noQuestionsInFile": {
     "description": "Mensaje mostrado cuando un archivo importado no contiene preguntas."

--- a/lib/core/l10n/app_eu.arb
+++ b/lib/core/l10n/app_eu.arb
@@ -1070,15 +1070,10 @@
   "@aiGenerationFailed": {
     "description": "AI galdera sorkuntza huts egiten duenean erakusten den mezua."
   },
-  "aiGenerationError": "Errorea galderak sortzean: {error}",
-  "@aiGenerationError": {
-    "description": "AI-rekin galderak sortzean errore mezua.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "API gako baliogabea"
-      }
-    }
+
+  "aiGenerationErrorTitle": "Errorea galderak sortzean",
+  "@aiGenerationErrorTitle": {
+    "description": "AI bidez galderak sortzean errore-leihoaren izenburua."
   },
   "noQuestionsInFile": "Ez da galderarik aurkitu inportatutako fitxategian",
   "@noQuestionsInFile": {

--- a/lib/core/l10n/app_fr.arb
+++ b/lib/core/l10n/app_fr.arb
@@ -1066,15 +1066,10 @@
   "@aiGenerationFailed": {
     "description": "Message affiché lorsque la génération de questions IA échoue."
   },
-  "aiGenerationError": "Erreur de génération de questions : {error}",
-  "@aiGenerationError": {
-    "description": "Message d'erreur lors de la génération de questions avec l'IA.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "Clé API invalide"
-      }
-    }
+
+  "aiGenerationErrorTitle": "Erreur de génération de questions",
+  "@aiGenerationErrorTitle": {
+    "description": "Titre de la boîte de dialogue d'erreur lors de la génération de questions avec l'IA."
   },
   "noQuestionsInFile": "Aucune question trouvée dans le fichier importé",
   "@noQuestionsInFile": {

--- a/lib/core/l10n/app_gl.arb
+++ b/lib/core/l10n/app_gl.arb
@@ -1088,15 +1088,10 @@
   "@aiGenerationFailed": {
     "description": "Mensaxe mostrada cando a xeración de preguntas IA falla."
   },
-  "aiGenerationError": "Erro xerando preguntas: {error}",
-  "@aiGenerationError": {
-    "description": "Mensaxe de erro en xerar preguntas con IA.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "Clave API non válida"
-      }
-    }
+
+  "aiGenerationErrorTitle": "Erro xerando preguntas",
+  "@aiGenerationErrorTitle": {
+    "description": "Título para o diálogo de erro xerando preguntas con IA."
   },
   "noQuestionsInFile": "Non se atoparon preguntas no ficheiro importado",
   "@noQuestionsInFile": {

--- a/lib/core/l10n/app_hi.arb
+++ b/lib/core/l10n/app_hi.arb
@@ -1078,15 +1078,9 @@
   "@aiGenerationFailed": {
     "description": "Message shown when AI question generation fails."
   },
-  "aiGenerationError": "प्रश्न बनाने में त्रुटि: {error}",
-  "@aiGenerationError": {
-    "description": "Error message when generating questions with AI.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "API key invalid"
-      }
-    }
+  "aiGenerationErrorTitle": "प्रश्न बनाने में त्रुटि",
+  "@aiGenerationErrorTitle": {
+    "description": "AI के साथ प्रश्न बनाने में त्रुटि संवाद के लिए शीर्षक।"
   },
   "noQuestionsInFile": "आयातित फ़ाइल में कोई प्रश्न नहीं मिले",
   "@noQuestionsInFile": {

--- a/lib/core/l10n/app_it.arb
+++ b/lib/core/l10n/app_it.arb
@@ -1066,15 +1066,10 @@
   "@aiGenerationFailed": {
     "description": "Messaggio mostrato quando la generazione domande IA fallisce."
   },
-  "aiGenerationError": "Errore nella generazione domande: {error}",
-  "@aiGenerationError": {
-    "description": "Messaggio di errore durante la generazione domande con IA.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "Chiave API non valida"
-      }
-    }
+
+  "aiGenerationErrorTitle": "Errore nella generazione domande",
+  "@aiGenerationErrorTitle": {
+    "description": "Titolo per la finestra di dialogo di errore durante la generazione di domande con IA."
   },
   "noQuestionsInFile": "Nessuna domanda trovata nel file importato",
   "@noQuestionsInFile": {

--- a/lib/core/l10n/app_ja.arb
+++ b/lib/core/l10n/app_ja.arb
@@ -1078,15 +1078,9 @@
   "@aiGenerationFailed": {
     "description": "Message shown when AI question generation fails."
   },
-  "aiGenerationError": "問題生成エラー：{error}",
-  "@aiGenerationError": {
-    "description": "Error message when generating questions with AI.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "API key invalid"
-      }
-    }
+  "aiGenerationErrorTitle": "問題生成エラー",
+  "@aiGenerationErrorTitle": {
+    "description": "AIによる問題生成時のエラーダイアログのタイトル。"
   },
   "noQuestionsInFile": "インポートされたファイルに問題が見つかりませんでした",
   "@noQuestionsInFile": {

--- a/lib/core/l10n/app_localizations.dart
+++ b/lib/core/l10n/app_localizations.dart
@@ -1586,11 +1586,11 @@ abstract class AppLocalizations {
   /// **'Could not generate questions. Try with different content.'**
   String get aiGenerationFailed;
 
-  /// Error message when generating questions with AI.
+  /// Title for the error dialog when generating questions with AI.
   ///
   /// In en, this message translates to:
-  /// **'Error generating questions: {error}'**
-  String aiGenerationError(String error);
+  /// **'Error generating questions'**
+  String get aiGenerationErrorTitle;
 
   /// Message shown when an imported file contains no questions.
   ///

--- a/lib/core/l10n/app_localizations_ar.dart
+++ b/lib/core/l10n/app_localizations_ar.dart
@@ -840,9 +840,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'لم أتمكن من إنتاج الأسئلة. جرب بمحتوى مختلف.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'خطأ في إنتاج الأسئلة: $error';
-  }
+  String get aiGenerationErrorTitle => 'خطأ في إنتاج الأسئلة';
 
   @override
   String get noQuestionsInFile => 'لم توجد أسئلة في الملف المستورد';

--- a/lib/core/l10n/app_localizations_ca.dart
+++ b/lib/core/l10n/app_localizations_ca.dart
@@ -855,9 +855,7 @@ class AppLocalizationsCa extends AppLocalizations {
       'No s\'han pogut generar preguntes. Proveu amb contingut diferent.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'Error en generar preguntes: $error';
-  }
+  String get aiGenerationErrorTitle => 'Error en generar preguntes';
 
   @override
   String get noQuestionsInFile => 'Cap pregunta trobada al fitxer importat';

--- a/lib/core/l10n/app_localizations_de.dart
+++ b/lib/core/l10n/app_localizations_de.dart
@@ -858,9 +858,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Fragen konnten nicht generiert werden. Versuchen Sie es mit anderem Inhalt.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'Fehler beim Generieren von Fragen: $error';
-  }
+  String get aiGenerationErrorTitle => 'Fehler beim Generieren von Fragen';
 
   @override
   String get noQuestionsInFile =>

--- a/lib/core/l10n/app_localizations_el.dart
+++ b/lib/core/l10n/app_localizations_el.dart
@@ -859,9 +859,7 @@ class AppLocalizationsEl extends AppLocalizations {
       'Αδυναμία δημιουργίας ερωτήσεων. Δοκιμάστε με διαφορετικό περιεχόμενο.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'Σφάλμα δημιουργίας ερωτήσεων: $error';
-  }
+  String get aiGenerationErrorTitle => 'Σφάλμα δημιουργίας ερωτήσεων';
 
   @override
   String get noQuestionsInFile =>

--- a/lib/core/l10n/app_localizations_en.dart
+++ b/lib/core/l10n/app_localizations_en.dart
@@ -848,9 +848,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Could not generate questions. Try with different content.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'Error generating questions: $error';
-  }
+  String get aiGenerationErrorTitle => 'Error generating questions';
 
   @override
   String get noQuestionsInFile => 'No questions found in the imported file';

--- a/lib/core/l10n/app_localizations_es.dart
+++ b/lib/core/l10n/app_localizations_es.dart
@@ -854,9 +854,7 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudieron generar preguntas. Intenta con un contenido diferente.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'Error al generar preguntas: $error';
-  }
+  String get aiGenerationErrorTitle => 'Error al generar preguntas';
 
   @override
   String get noQuestionsInFile =>

--- a/lib/core/l10n/app_localizations_eu.dart
+++ b/lib/core/l10n/app_localizations_eu.dart
@@ -854,9 +854,7 @@ class AppLocalizationsEu extends AppLocalizations {
       'Ezin izan dira galderak sortu. Saiatu eduki ezberdinarekin.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'Errorea galderak sortzean: $error';
-  }
+  String get aiGenerationErrorTitle => 'Errorea galderak sortzean';
 
   @override
   String get noQuestionsInFile =>

--- a/lib/core/l10n/app_localizations_fr.dart
+++ b/lib/core/l10n/app_localizations_fr.dart
@@ -858,9 +858,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Impossible de générer des questions. Essayez avec un contenu différent.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'Erreur de génération de questions : $error';
-  }
+  String get aiGenerationErrorTitle => 'Erreur de génération de questions';
 
   @override
   String get noQuestionsInFile =>

--- a/lib/core/l10n/app_localizations_gl.dart
+++ b/lib/core/l10n/app_localizations_gl.dart
@@ -857,9 +857,7 @@ class AppLocalizationsGl extends AppLocalizations {
       'Non se puideron xerar preguntas. Proba con contido diferente.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'Erro xerando preguntas: $error';
-  }
+  String get aiGenerationErrorTitle => 'Erro xerando preguntas';
 
   @override
   String get noQuestionsInFile =>

--- a/lib/core/l10n/app_localizations_hi.dart
+++ b/lib/core/l10n/app_localizations_hi.dart
@@ -846,9 +846,7 @@ class AppLocalizationsHi extends AppLocalizations {
       'प्रश्न नहीं बना सके। अलग सामग्री के साथ प्रयास करें।';
 
   @override
-  String aiGenerationError(String error) {
-    return 'प्रश्न बनाने में त्रुटि: $error';
-  }
+  String get aiGenerationErrorTitle => 'प्रश्न बनाने में त्रुटि';
 
   @override
   String get noQuestionsInFile => 'आयातित फ़ाइल में कोई प्रश्न नहीं मिले';

--- a/lib/core/l10n/app_localizations_it.dart
+++ b/lib/core/l10n/app_localizations_it.dart
@@ -852,9 +852,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'Impossibile generare domande. Prova con contenuto diverso.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'Errore nella generazione domande: $error';
-  }
+  String get aiGenerationErrorTitle => 'Errore nella generazione domande';
 
   @override
   String get noQuestionsInFile => 'Nessuna domanda trovata nel file importato';

--- a/lib/core/l10n/app_localizations_ja.dart
+++ b/lib/core/l10n/app_localizations_ja.dart
@@ -813,9 +813,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get aiGenerationFailed => '問題を生成できませんでした。異なるコンテンツで試してください。';
 
   @override
-  String aiGenerationError(String error) {
-    return '問題生成エラー：$error';
-  }
+  String get aiGenerationErrorTitle => '問題生成エラー';
 
   @override
   String get noQuestionsInFile => 'インポートされたファイルに問題が見つかりませんでした';

--- a/lib/core/l10n/app_localizations_pt.dart
+++ b/lib/core/l10n/app_localizations_pt.dart
@@ -853,9 +853,7 @@ class AppLocalizationsPt extends AppLocalizations {
       'Não foi possível gerar perguntas. Tente com conteúdo diferente.';
 
   @override
-  String aiGenerationError(String error) {
-    return 'Erro ao gerar perguntas: $error';
-  }
+  String get aiGenerationErrorTitle => 'Erro ao gerar perguntas';
 
   @override
   String get noQuestionsInFile =>

--- a/lib/core/l10n/app_localizations_zh.dart
+++ b/lib/core/l10n/app_localizations_zh.dart
@@ -808,9 +808,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get aiGenerationFailed => '无法生成问题。请尝试不同的内容。';
 
   @override
-  String aiGenerationError(String error) {
-    return '生成问题时出错：$error';
-  }
+  String get aiGenerationErrorTitle => '生成问题时出错';
 
   @override
   String get noQuestionsInFile => '导入的文件中未找到问题';

--- a/lib/core/l10n/app_pt.arb
+++ b/lib/core/l10n/app_pt.arb
@@ -1066,15 +1066,10 @@
   "@aiGenerationFailed": {
     "description": "Mensagem mostrada quando geração de perguntas IA falha."
   },
-  "aiGenerationError": "Erro ao gerar perguntas: {error}",
-  "@aiGenerationError": {
-    "description": "Mensagem de erro ao gerar perguntas com IA.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "Chave API inválida"
-      }
-    }
+
+  "aiGenerationErrorTitle": "Erro ao gerar perguntas",
+  "@aiGenerationErrorTitle": {
+    "description": "Título para o diálogo de erro ao gerar perguntas com IA."
   },
   "noQuestionsInFile": "Nenhuma pergunta encontrada no arquivo importado",
   "@noQuestionsInFile": {

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -1070,15 +1070,9 @@
   "@aiGenerationFailed": {
     "description": "Message shown when AI question generation fails."
   },
-  "aiGenerationError": "生成问题时出错：{error}",
-  "@aiGenerationError": {
-    "description": "Error message when generating questions with AI.",
-    "placeholders": {
-      "error": {
-        "type": "String",
-        "example": "API key invalid"
-      }
-    }
+  "aiGenerationErrorTitle": "生成问题时出错",
+  "@aiGenerationErrorTitle": {
+    "description": "AI 生成问题出错时的对话框标题。"
   },
   "noQuestionsInFile": "导入的文件中未找到问题",
   "@noQuestionsInFile": {

--- a/lib/presentation/screens/dialogs/custom_confirm_dialog.dart
+++ b/lib/presentation/screens/dialogs/custom_confirm_dialog.dart
@@ -58,14 +58,21 @@ class CustomConfirmDialog extends StatelessWidget {
       elevation: 0,
       insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
       child: Container(
-        constraints: const BoxConstraints(maxWidth: 400),
+        constraints: const BoxConstraints(maxWidth: 520),
         width: MediaQuery.of(context).size.width,
         decoration: BoxDecoration(
           color: backgroundColor,
           borderRadius: BorderRadius.circular(24),
           border: Border.all(color: borderColor, width: 1),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.1),
+              blurRadius: 20,
+              offset: const Offset(0, 10),
+            ),
+          ],
         ),
-        padding: const EdgeInsets.all(24),
+        padding: const EdgeInsets.all(32),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -74,18 +81,21 @@ class CustomConfirmDialog extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(
-                  title,
-                  style: TextStyle(
-                    fontFamily: 'Inter',
-                    fontSize: 18,
-                    fontWeight: FontWeight.w700,
-                    color: titleColor,
+                Expanded(
+                  child: Text(
+                    title,
+                    style: TextStyle(
+                      fontFamily: 'Inter',
+                      fontSize: 24,
+                      fontWeight: FontWeight.w700,
+                      color: titleColor,
+                    ),
                   ),
                 ),
                 Container(
                   width: 40,
                   height: 40,
+                  margin: const EdgeInsets.only(left: 16),
                   decoration: BoxDecoration(
                     color: closeBtnColor,
                     borderRadius: BorderRadius.circular(20),
@@ -119,12 +129,12 @@ class CustomConfirmDialog extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(height: 24),
+            const SizedBox(height: 32),
 
             // Actions
             SizedBox(
               width: double.infinity,
-              height: 52,
+              height: 56,
               child: FilledButton(
                 onPressed: () {
                   onConfirm?.call();

--- a/lib/presentation/screens/file_loaded_screen.dart
+++ b/lib/presentation/screens/file_loaded_screen.dart
@@ -337,10 +337,13 @@ class _FileLoadedScreenState extends State<FileLoadedScreen> {
         if (mounted) {
           context.pop();
 
-          context.presentSnackBar(
-            AppLocalizations.of(
-              context,
-            )!.aiGenerationError(e.toString().cleanExceptionPrefix()),
+          showDialog(
+            context: context,
+            builder: (context) => CustomConfirmDialog(
+              title: AppLocalizations.of(context)!.aiGenerationErrorTitle,
+              message: e.toString().cleanExceptionPrefix(),
+              confirmText: AppLocalizations.of(context)!.acceptButton,
+            ),
           );
         }
       }


### PR DESCRIPTION
## Changes
- Replaced the hardcoded 'Error generating questions' title with a new localized 'aiGenerationErrorTitle' string across all languages.
- Removed the unused 'aiGenerationError' localized string and its metadata from all ARB files.
- Updated the AI error dialog in  to display the raw exception message while using the localized title.

This ensures a consistent and properly localized error title while keeping the detailed technical error message intact.

Light Mode:
<img width="2664" height="1638" alt="image" src="https://github.com/user-attachments/assets/0ad9d7e5-a36d-435c-a848-3841b17525d3" />

Dark Mode:
<img width="2664" height="1638" alt="image" src="https://github.com/user-attachments/assets/bb858a30-ff5d-4da9-ac5b-b6ec19c88172" />
