### PR TITLE
feat: allow manual editing of question count in AI generation dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.0]
 
+- feat: Allow manual editing of the number of questions in the AI generation dialog via a text field.
 - fix: Prevent collapsing a `QuestionPreviewCard` when tapping collapsible content.
 
 ## [1.6.0] - 2026-02-11

--- a/lib/presentation/screens/dialogs/ai_generate_questions_dialog.dart
+++ b/lib/presentation/screens/dialogs/ai_generate_questions_dialog.dart
@@ -367,6 +367,7 @@ class _AiGenerateQuestionsDialogState extends State<AiGenerateQuestionsDialog> {
     } else {
       return AiGenerateStep2Widget(
         textController: _textController,
+        questionCountController: _questionCountController,
         questionCount: _questionCount,
         fileAttachment: _fileAttachment,
         selectedQuestionTypes: _selectedQuestionTypes,
@@ -387,7 +388,9 @@ class _AiGenerateQuestionsDialogState extends State<AiGenerateQuestionsDialog> {
         onQuestionCountChanged: (count) {
           setState(() {
             _questionCount = count;
-            _questionCountController.text = count.toString();
+            if (_questionCountController.text != count.toString()) {
+              _questionCountController.text = count.toString();
+            }
           });
         },
         getWordCountText: _getWordCountText,


### PR DESCRIPTION
This PR implements manual editing of the number of questions in the AI generation dialog via a text field, in addition to the existing +/- buttons. It also enforces a range of 1-50 questions and includes numeric validation.
- Closes #148