### PR TITLE
Update pasteboard to 0.5.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -584,12 +584,11 @@ packages:
   pasteboard:
     dependency: "direct main"
     description:
-      path: "packages/pasteboard"
-      ref: "feature/spm-support"
-      resolved-ref: "0da82d63ad17726aa609d89496398dcec8852418"
-      url: "https://github.com/vicajilau/flutter-plugins.git"
-    source: git
-    version: "0.4.0"
+      name: pasteboard
+      sha256: fedbe8da188d2f713aa8b01260737342e6e1087534a3ab26e1a719f8d3e8f32f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,12 +58,7 @@ dependencies:
   lucide_icons: ^0.257.0
   path_provider: ^2.1.5
   collection: ^1.19.1
-  # Until https://github.com/MixinNetwork/flutter-plugins/pull/463 gets merged
-  pasteboard:
-    git:
-      url: https://github.com/vicajilau/flutter-plugins.git
-      ref: feature/spm-support
-      path: packages/pasteboard
+  pasteboard: ^0.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updates the pasteboard dependency to the official 0.5.0 version, as the changes have been merged. Closes #164.