### PR TITLE
fix: expand question preview card tap area over title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.2]
 
+- fix: Expanded click area to include the question title for expanding and collapsing the `QuestionPreviewCard`.
 - feat: Added "Paste" button to API key text fields in settings for quicker setup.
 - fix: AI Generation dialog now properly saves and restores attached file paths across sessions.
 

--- a/lib/presentation/screens/widgets/question_preview_card.dart
+++ b/lib/presentation/screens/widgets/question_preview_card.dart
@@ -92,277 +92,297 @@ class _QuestionPreviewCardState extends State<QuestionPreviewCard> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Header with Question Index Badge and Actions
+          // Header and Question Text wrapped together for combined tap area
           GestureDetector(
+            behavior: HitTestBehavior.opaque,
             onTap: widget.isSelectionMode
                 ? widget.onSelectionToggle
                 : _toggleExpanded,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  return ScrollConfiguration(
-                    behavior: ScrollConfiguration.of(context).copyWith(
-                      dragDevices: {
-                        PointerDeviceKind.touch,
-                        PointerDeviceKind.mouse,
-                      },
-                    ),
-                    child: SingleChildScrollView(
-                      scrollDirection: Axis.horizontal,
-                      child: ConstrainedBox(
-                        constraints: BoxConstraints(
-                          minWidth: constraints.maxWidth,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Header with Question Index Badge and Actions
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      return ScrollConfiguration(
+                        behavior: ScrollConfiguration.of(context).copyWith(
+                          dragDevices: {
+                            PointerDeviceKind.touch,
+                            PointerDeviceKind.mouse,
+                          },
                         ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            // Left Group: Selection + Badge + Type
-                            Row(
-                              mainAxisSize: MainAxisSize.min,
+                        child: SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: ConstrainedBox(
+                            constraints: BoxConstraints(
+                              minWidth: constraints.maxWidth,
+                            ),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
                               children: [
-                                if (widget.isSelectionMode) ...[
-                                  Container(
-                                    width: 24,
-                                    height: 24,
-                                    decoration: BoxDecoration(
-                                      color: widget.isSelected
-                                          ? Theme.of(context)
-                                                .extension<CustomColors>()!
-                                                .aiIconColor!
-                                          : Colors.transparent,
-                                      shape: BoxShape.circle,
-                                      border: Border.all(
-                                        color: widget.isSelected
-                                            ? Theme.of(context)
-                                                  .extension<CustomColors>()!
-                                                  .aiIconColor!
-                                            : Theme.of(context).hintColor,
-                                      ),
-                                    ),
-                                    child: widget.isSelected
-                                        ? const Icon(
-                                            LucideIcons.check,
-                                            size: 16,
-                                            color: Colors.white,
-                                          )
-                                        : null,
-                                  ),
-                                  const SizedBox(width: 12),
-                                ],
-
-                                // Question Badge
-                                Container(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 12,
-                                    vertical: 6,
-                                  ),
-                                  decoration: BoxDecoration(
-                                    color: Theme.of(context).dividerColor,
-                                    borderRadius: BorderRadius.circular(20),
-                                  ),
-                                  child: Text(
-                                    (widget.index + 1).toString().padLeft(
-                                      2,
-                                      '0',
-                                    ),
-                                    style: TextStyle(
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.onSurface,
-                                      fontSize: 12,
-                                      fontWeight: FontWeight.w600,
-                                      fontFamily: 'Inter',
-                                    ),
-                                  ),
-                                ),
-
-                                const SizedBox(width: 8),
-
-                                // Question Type Badge (Always Full)
-                                Tooltip(
-                                  message: AppLocalizations.of(context)!
-                                      .questionTypeTooltip(
-                                        QuestionTypeIndicator.getQuestionTypeString(
-                                          context,
-                                          widget.question.type,
+                                // Left Group: Selection + Badge + Type
+                                Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    if (widget.isSelectionMode) ...[
+                                      Container(
+                                        width: 24,
+                                        height: 24,
+                                        decoration: BoxDecoration(
+                                          color: widget.isSelected
+                                              ? Theme.of(context)
+                                                    .extension<CustomColors>()!
+                                                    .aiIconColor!
+                                              : Colors.transparent,
+                                          shape: BoxShape.circle,
+                                          border: Border.all(
+                                            color: widget.isSelected
+                                                ? Theme.of(context)
+                                                      .extension<
+                                                        CustomColors
+                                                      >()!
+                                                      .aiIconColor!
+                                                : Theme.of(context).hintColor,
+                                          ),
                                         ),
+                                        child: widget.isSelected
+                                            ? const Icon(
+                                                LucideIcons.check,
+                                                size: 16,
+                                                color: Colors.white,
+                                              )
+                                            : null,
                                       ),
-                                  child: Container(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 8,
-                                      vertical: 4,
-                                    ),
-                                    decoration: BoxDecoration(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .onSurface
-                                          .withValues(alpha: 0.1),
-                                      borderRadius: BorderRadius.circular(8),
-                                    ),
-                                    child: QuestionTypeIndicator(
-                                      questionType: widget.question.type,
-                                      showText: constraints.maxWidth > 340,
-                                    ),
-                                  ),
-                                ),
+                                      const SizedBox(width: 12),
+                                    ],
 
-                                if (widget.question.explanation.isEmpty) ...[
-                                  const SizedBox(width: 8),
-                                  Tooltip(
-                                    message: AppLocalizations.of(
-                                      context,
-                                    )!.missingExplanationTooltip,
-                                    child: Container(
+                                    // Question Badge
+                                    Container(
                                       padding: const EdgeInsets.symmetric(
-                                        horizontal: 8,
-                                        vertical: 4,
+                                        horizontal: 12,
+                                        vertical: 6,
                                       ),
                                       decoration: BoxDecoration(
-                                        color: Theme.of(context)
-                                            .extension<CustomColors>()!
-                                            .warningContainer,
-                                        borderRadius: BorderRadius.circular(8),
+                                        color: Theme.of(context).dividerColor,
+                                        borderRadius: BorderRadius.circular(20),
                                       ),
-                                      child: Row(
-                                        mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          Icon(
-                                            LucideIcons.alertTriangle,
-                                            size: 12,
+                                      child: Text(
+                                        (widget.index + 1).toString().padLeft(
+                                          2,
+                                          '0',
+                                        ),
+                                        style: TextStyle(
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.onSurface,
+                                          fontSize: 12,
+                                          fontWeight: FontWeight.w600,
+                                          fontFamily: 'Inter',
+                                        ),
+                                      ),
+                                    ),
+
+                                    const SizedBox(width: 8),
+
+                                    // Question Type Badge (Always Full)
+                                    Tooltip(
+                                      message: AppLocalizations.of(context)!
+                                          .questionTypeTooltip(
+                                            QuestionTypeIndicator.getQuestionTypeString(
+                                              context,
+                                              widget.question.type,
+                                            ),
+                                          ),
+                                      child: Container(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 8,
+                                          vertical: 4,
+                                        ),
+                                        decoration: BoxDecoration(
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .onSurface
+                                              .withValues(alpha: 0.1),
+                                          borderRadius: BorderRadius.circular(
+                                            8,
+                                          ),
+                                        ),
+                                        child: QuestionTypeIndicator(
+                                          questionType: widget.question.type,
+                                          showText: constraints.maxWidth > 340,
+                                        ),
+                                      ),
+                                    ),
+
+                                    if (widget
+                                        .question
+                                        .explanation
+                                        .isEmpty) ...[
+                                      const SizedBox(width: 8),
+                                      Tooltip(
+                                        message: AppLocalizations.of(
+                                          context,
+                                        )!.missingExplanationTooltip,
+                                        child: Container(
+                                          padding: const EdgeInsets.symmetric(
+                                            horizontal: 8,
+                                            vertical: 4,
+                                          ),
+                                          decoration: BoxDecoration(
                                             color: Theme.of(context)
                                                 .extension<CustomColors>()!
-                                                .onWarningContainer,
+                                                .warningContainer,
+                                            borderRadius: BorderRadius.circular(
+                                              8,
+                                            ),
                                           ),
-                                          if (constraints.maxWidth > 340) ...[
-                                            const SizedBox(width: 4),
-                                            Text(
-                                              AppLocalizations.of(
-                                                context,
-                                              )!.missingExplanation,
-                                              style: TextStyle(
+                                          child: Row(
+                                            mainAxisSize: MainAxisSize.min,
+                                            children: [
+                                              Icon(
+                                                LucideIcons.alertTriangle,
+                                                size: 12,
                                                 color: Theme.of(context)
                                                     .extension<CustomColors>()!
                                                     .onWarningContainer,
-                                                fontSize:
-                                                    Theme.of(
-                                                          context,
-                                                        ).brightness ==
-                                                        Brightness.dark
-                                                    ? 11
-                                                    : 10,
-                                                fontWeight:
-                                                    Theme.of(
-                                                          context,
-                                                        ).brightness ==
-                                                        Brightness.dark
-                                                    ? FontWeight.w500
-                                                    : FontWeight.w600,
-                                                fontFamily: 'Inter',
                                               ),
-                                            ),
-                                          ],
-                                        ],
+                                              if (constraints.maxWidth >
+                                                  340) ...[
+                                                const SizedBox(width: 4),
+                                                Text(
+                                                  AppLocalizations.of(
+                                                    context,
+                                                  )!.missingExplanation,
+                                                  style: TextStyle(
+                                                    color: Theme.of(context)
+                                                        .extension<
+                                                          CustomColors
+                                                        >()!
+                                                        .onWarningContainer,
+                                                    fontSize:
+                                                        Theme.of(
+                                                              context,
+                                                            ).brightness ==
+                                                            Brightness.dark
+                                                        ? 11
+                                                        : 10,
+                                                    fontWeight:
+                                                        Theme.of(
+                                                              context,
+                                                            ).brightness ==
+                                                            Brightness.dark
+                                                        ? FontWeight.w500
+                                                        : FontWeight.w600,
+                                                    fontFamily: 'Inter',
+                                                  ),
+                                                ),
+                                              ],
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+
+                                    // Minimum gap before actions
+                                    const SizedBox(width: 16),
+                                  ],
+                                ),
+
+                                // Right Group: Actions (Pinned to right if space allows)
+                                if (widget.isSelectionMode)
+                                  ReorderableDragStartListener(
+                                    index: widget.index,
+                                    child: Padding(
+                                      padding: const EdgeInsets.all(4.0),
+                                      child: Icon(
+                                        Icons.drag_indicator,
+                                        color: Theme.of(context).hintColor,
                                       ),
                                     ),
+                                  )
+                                else
+                                  Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      if (widget.onAiAssistant != null &&
+                                          !isDisabled)
+                                        _buildIconButton(
+                                          icon: LucideIcons.sparkles,
+                                          color: Theme.of(context)
+                                              .extension<CustomColors>()!
+                                              .aiIconColor!,
+                                          onPressed: widget.onAiAssistant!,
+                                          tooltip: AppLocalizations.of(
+                                            context,
+                                          )!.aiButtonTooltip,
+                                        ),
+                                      const SizedBox(width: 8),
+                                      _buildIconButton(
+                                        icon: LucideIcons.pencil,
+                                        color: Theme.of(
+                                          context,
+                                        ).extension<CustomColors>()!.info!,
+                                        onPressed: widget.onEdit,
+                                        tooltip: AppLocalizations.of(
+                                          context,
+                                        )!.edit,
+                                      ),
+                                      const SizedBox(width: 8),
+                                      _buildIconButton(
+                                        icon: LucideIcons.trash2,
+                                        color: Theme.of(
+                                          context,
+                                        ).colorScheme.error,
+                                        onPressed: widget.onDelete,
+                                        tooltip: AppLocalizations.of(
+                                          context,
+                                        )!.deleteButton,
+                                      ),
+                                      const SizedBox(width: 8),
+                                      _buildIconButton(
+                                        icon: _isExpanded
+                                            ? LucideIcons.chevronUp
+                                            : LucideIcons.chevronDown,
+                                        color: Theme.of(context).hintColor,
+                                        onPressed: _toggleExpanded,
+                                        tooltip: _isExpanded
+                                            ? 'Collapse'
+                                            : 'Expand',
+                                      ),
+                                    ],
                                   ),
-                                ],
-
-                                // Minimum gap before actions
-                                const SizedBox(width: 16),
                               ],
                             ),
-
-                            // Right Group: Actions (Pinned to right if space allows)
-                            if (widget.isSelectionMode)
-                              ReorderableDragStartListener(
-                                index: widget.index,
-                                child: Padding(
-                                  padding: const EdgeInsets.all(4.0),
-                                  child: Icon(
-                                    Icons.drag_indicator,
-                                    color: Theme.of(context).hintColor,
-                                  ),
-                                ),
-                              )
-                            else
-                              Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  if (widget.onAiAssistant != null &&
-                                      !isDisabled)
-                                    _buildIconButton(
-                                      icon: LucideIcons.sparkles,
-                                      color: Theme.of(
-                                        context,
-                                      ).extension<CustomColors>()!.aiIconColor!,
-                                      onPressed: widget.onAiAssistant!,
-                                      tooltip: AppLocalizations.of(
-                                        context,
-                                      )!.aiButtonTooltip,
-                                    ),
-                                  const SizedBox(width: 8),
-                                  _buildIconButton(
-                                    icon: LucideIcons.pencil,
-                                    color: Theme.of(
-                                      context,
-                                    ).extension<CustomColors>()!.info!,
-                                    onPressed: widget.onEdit,
-                                    tooltip: AppLocalizations.of(context)!.edit,
-                                  ),
-                                  const SizedBox(width: 8),
-                                  _buildIconButton(
-                                    icon: LucideIcons.trash2,
-                                    color: Theme.of(context).colorScheme.error,
-                                    onPressed: widget.onDelete,
-                                    tooltip: AppLocalizations.of(
-                                      context,
-                                    )!.deleteButton,
-                                  ),
-                                  const SizedBox(width: 8),
-                                  _buildIconButton(
-                                    icon: _isExpanded
-                                        ? LucideIcons.chevronUp
-                                        : LucideIcons.chevronDown,
-                                    color: Theme.of(context).hintColor,
-                                    onPressed: _toggleExpanded,
-                                    tooltip: _isExpanded
-                                        ? 'Collapse'
-                                        : 'Expand',
-                                  ),
-                                ],
-                              ),
-                          ],
+                          ),
                         ),
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-          ),
-
-          // Question Text Preview (Always visible)
-          GestureDetector(
-            onTap: widget.isSelectionMode
-                ? widget.onSelectionToggle
-                : _toggleExpanded,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 20,
-              ).copyWith(bottom: 20),
-              child: LaTeXText(
-                widget.question.text,
-                maxLines: _isExpanded ? 100 : 2,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.onSurface,
-                  fontSize: 15,
-                  fontWeight: FontWeight.w500,
-                  fontFamily: 'Inter',
-                  decoration: isDisabled ? TextDecoration.lineThrough : null,
+                      );
+                    },
+                  ),
                 ),
-              ),
+
+                // Question Text Preview (Always visible)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 20,
+                  ).copyWith(bottom: 20),
+                  child: LaTeXText(
+                    widget.question.text,
+                    maxLines: _isExpanded ? 100 : 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.onSurface,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w500,
+                      fontFamily: 'Inter',
+                      decoration: isDisabled
+                          ? TextDecoration.lineThrough
+                          : null,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
 


### PR DESCRIPTION
Resolves #206. Expanded click area to include the question title when expanding or collapsing the `QuestionPreviewCard`.