### PR TITLE
fix: use geometric container to avoid optical offset bug in font icons

### DIFF
--- a/lib/presentation/screens/quiz_execution/widgets/question_option_tile.dart
+++ b/lib/presentation/screens/quiz_execution/widgets/question_option_tile.dart
@@ -166,10 +166,18 @@ class QuestionOptionTile extends StatelessWidget {
                   color: Colors.transparent,
                 ),
                 child: isSelected
-                    ? Icon(
-                        isMultipleChoice ? Icons.square_rounded : Icons.circle,
-                        size: 16,
-                        color: iconColor,
+                    ? Container(
+                        width: 14,
+                        height: 14,
+                        decoration: BoxDecoration(
+                          shape: isMultipleChoice
+                              ? BoxShape.rectangle
+                              : BoxShape.circle,
+                          borderRadius: isMultipleChoice
+                              ? BorderRadius.circular(4)
+                              : null,
+                          color: iconColor,
+                        ),
                       )
                     : null,
               ),

--- a/lib/presentation/screens/quiz_execution/widgets/quiz_question_options_result.dart
+++ b/lib/presentation/screens/quiz_execution/widgets/quiz_question_options_result.dart
@@ -123,12 +123,18 @@ class QuizQuestionOptionsResult extends StatelessWidget {
                     color: Colors.transparent,
                   ),
                   child: iconColor != null
-                      ? Icon(
-                          isMultipleChoice
-                              ? Icons.square_rounded
-                              : Icons.circle,
-                          size: 16,
-                          color: iconColor,
+                      ? Container(
+                          width: 14,
+                          height: 14,
+                          decoration: BoxDecoration(
+                            shape: isMultipleChoice
+                                ? BoxShape.rectangle
+                                : BoxShape.circle,
+                            borderRadius: isMultipleChoice
+                                ? BorderRadius.circular(4)
+                                : null,
+                            color: iconColor,
+                          ),
                         )
                       : null,
                 ),


### PR DESCRIPTION
Resolves https://github.com/vicajilau/quizdy/issues/213. Replaced generic checkmarks in question options with shape-based indicators (rounded squares for multiple choice, circles for single choice) to clearly convey the question type to the user.