### PR TITLE
Implement Gemini file re-upload and expiration handling

### DIFF
--- a/lib/data/services/ai/ai_service.dart
+++ b/lib/data/services/ai/ai_service.dart
@@ -17,6 +17,13 @@ import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/domain/models/ai/ai_file_attachment.dart';
 import 'package:quizdy/domain/models/ai/ai_generation_mode.dart';
 
+class FileUploadResult {
+  final String fileUri;
+  final DateTime expirationTime;
+
+  FileUploadResult({required this.fileUri, required this.expirationTime});
+}
+
 abstract class AIService {
   /// Obtiene una respuesta del servicio de IA basado en el prompt proporcionado
   Future<String> getChatResponse(
@@ -35,8 +42,8 @@ abstract class AIService {
     required AiFileAttachment file,
   });
 
-  /// Sube un archivo al servicio de IA y devuelve su URI o identificador
-  Future<String> uploadFile(
+  /// Sube un archivo al servicio de IA y devuelve su URI y fecha de expiración
+  Future<FileUploadResult> uploadFile(
     AiFileAttachment file,
     AppLocalizations localizations,
   );

--- a/lib/data/services/ai/gemini_service.dart
+++ b/lib/data/services/ai/gemini_service.dart
@@ -255,7 +255,7 @@ class GeminiService extends AIService {
   }
 
   @override
-  Future<String> uploadFile(
+  Future<FileUploadResult> uploadFile(
     AiFileAttachment file,
     AppLocalizations localizations,
   ) async {
@@ -297,9 +297,13 @@ class GeminiService extends AIService {
 
       final jsonResponse = response.data;
       final fileUri = jsonResponse['file']?['uri'] as String?;
+      final expirationTimeStr = jsonResponse['file']?['expirationTime'] as String?;
 
-      if (fileUri != null) {
-        return fileUri;
+      if (fileUri != null && expirationTimeStr != null) {
+        return FileUploadResult(
+          fileUri: fileUri,
+          expirationTime: DateTime.parse(expirationTimeStr),
+        );
       } else {
         throw Exception(localizations.noResponseReceived);
       }

--- a/lib/data/services/ai/openai_service.dart
+++ b/lib/data/services/ai/openai_service.dart
@@ -165,7 +165,7 @@ class OpenAIService extends AIService {
   }
 
   @override
-  Future<String> uploadFile(
+  Future<FileUploadResult> uploadFile(
     AiFileAttachment file,
     AppLocalizations localizations,
   ) async {

--- a/lib/domain/models/quiz/quiz_file.dart
+++ b/lib/domain/models/quiz/quiz_file.dart
@@ -48,6 +48,9 @@ class QuizFile {
   /// The URI of the uploaded file in the AI service (e.g. Gemini File API).
   final String? fileUri;
 
+  /// The expiration time of the uploaded file in the AI service.
+  final DateTime? fileExpirationTime;
+
   /// Get generationMode from study
   AiGenerationMode? get generationMode => study?.generationMode;
 
@@ -63,6 +66,7 @@ class QuizFile {
     this.fileAttachment,
     this.fileContentHash,
     this.fileUri,
+    this.fileExpirationTime,
   });
 
   /// Creates a `QuizFile` instance from a JSON map.
@@ -83,6 +87,10 @@ class QuizFile {
 
       final fileContentHash = json['fileContentHash'] as String?;
       final fileUri = json['fileUri'] as String?;
+      final fileExpirationTimeStr = json['fileExpirationTime'] as String?;
+      final fileExpirationTime = fileExpirationTimeStr != null
+          ? DateTime.parse(fileExpirationTimeStr)
+          : null;
 
       return QuizFile(
         metadata: metadata,
@@ -91,6 +99,7 @@ class QuizFile {
         filePath: filePath,
         fileContentHash: fileContentHash,
         fileUri: fileUri,
+        fileExpirationTime: fileExpirationTime,
       );
     } catch (e) {
       throw BadQuizFileException(
@@ -110,6 +119,8 @@ class QuizFile {
       'questions': questions.map((question) => question.toJson()).toList(),
       if (fileContentHash != null) 'fileContentHash': fileContentHash,
       if (fileUri != null) 'fileUri': fileUri,
+      if (fileExpirationTime != null)
+        'fileExpirationTime': fileExpirationTime!.toIso8601String(),
     };
   }
 
@@ -127,6 +138,7 @@ class QuizFile {
     AiFileAttachment? fileAttachment,
     String? fileContentHash,
     String? fileUri,
+    DateTime? fileExpirationTime,
     // Note: generationMode and originalText are now part of study
   }) {
     return QuizFile(
@@ -137,8 +149,9 @@ class QuizFile {
       fileAttachment: fileAttachment ?? this.fileAttachment,
       fileContentHash: fileContentHash ?? this.fileContentHash,
       fileUri: fileUri ?? this.fileUri,
+      fileExpirationTime: fileExpirationTime ?? this.fileExpirationTime,
     );
-  }
+}
 
   /// Creates a deep copy of the `QuizFile` with all nested objects copied.
   ///
@@ -154,6 +167,7 @@ class QuizFile {
       filePath: filePath,
       fileContentHash: fileContentHash,
       fileUri: fileUri,
+      fileExpirationTime: fileExpirationTime,
     );
   }
 
@@ -166,7 +180,8 @@ class QuizFile {
         other.study == study &&
         other.filePath == filePath &&
         other.fileContentHash == fileContentHash &&
-        other.fileUri == fileUri;
+        other.fileUri == fileUri &&
+        other.fileExpirationTime == fileExpirationTime;
   }
 
   @override
@@ -176,7 +191,8 @@ class QuizFile {
         study.hashCode ^
         filePath.hashCode ^
         fileContentHash.hashCode ^
-        fileUri.hashCode;
+        fileUri.hashCode ^
+        fileExpirationTime.hashCode;
   }
 
   @override

--- a/lib/domain/use_cases/initialize_quiz_chunks_use_case.dart
+++ b/lib/domain/use_cases/initialize_quiz_chunks_use_case.dart
@@ -85,6 +85,8 @@ class InitializeQuizChunksUseCase {
       study: study,
       fileAttachment: file,
       fileContentHash: file.contentHash,
+      fileUri: result['fileUri'] as String?,
+      fileExpirationTime: result['fileExpirationTime'] as DateTime?,
     );
   }
 
@@ -97,7 +99,9 @@ class InitializeQuizChunksUseCase {
     required String language,
   }) async {
     // 1. Upload the file to the AI service to get a URI (Gemini File API)
-    final fileUri = await _aiService.uploadFile(file, localizations);
+    final uploadResult = await _aiService.uploadFile(file, localizations);
+    final fileUri = uploadResult.fileUri;
+    final fileExpirationTime = uploadResult.expirationTime;
 
     // 2. Generate logical chunks using AI analysis of the uploaded file
     final indexResult = await _chunkingService.generateIndexWithAi(
@@ -123,6 +127,7 @@ class InitializeQuizChunksUseCase {
     return {
       'chunks': chunks,
       'fileUri': fileUri,
+      'fileExpirationTime': fileExpirationTime,
       'title': indexResult['title'] as String?,
       'description': indexResult['description'] as String?,
     };

--- a/lib/presentation/blocs/file_bloc/file_bloc.dart
+++ b/lib/presentation/blocs/file_bloc/file_bloc.dart
@@ -232,6 +232,7 @@ class FileBloc extends Bloc<FileEvent, FileState> {
         final updatedFile = currentFile.copyWith(
           study: updatedStudy,
           fileUri: event.fileUri,
+          fileExpirationTime: event.fileExpirationTime,
         );
 
         // Update repository/service locator without dropping the original unmodified cache state

--- a/lib/presentation/blocs/file_bloc/file_event.dart
+++ b/lib/presentation/blocs/file_bloc/file_event.dart
@@ -91,12 +91,14 @@ class StudyProgressUpdated extends FileEvent {
   final int processedChunks;
   final List<StudyChunk> chunks;
   final String? fileUri;
+  final DateTime? fileExpirationTime;
 
   StudyProgressUpdated({
     required this.progress,
     required this.processedChunks,
     required this.chunks,
     this.fileUri,
+    this.fileExpirationTime,
   });
 }
 

--- a/lib/presentation/blocs/study_execution_bloc/study_execution_bloc.dart
+++ b/lib/presentation/blocs/study_execution_bloc/study_execution_bloc.dart
@@ -36,6 +36,7 @@ class StudyExecutionBloc
     int processedChunks,
     List<StudyChunk> chunks,
     String? fileUri,
+    DateTime? fileExpirationTime,
   )?
   onProgressChanged;
   final bool _isAutoDifficulty;
@@ -57,6 +58,7 @@ class StudyExecutionBloc
     String? originalText,
     String? language,
     AiGenerationMode? generationMode,
+    DateTime? fileExpirationTime,
     this.onProgressChanged,
   }) : _jitProcessingService = jitProcessingService,
        _localizations = localizations,
@@ -72,6 +74,7 @@ class StudyExecutionBloc
            documentSummary,
            fileAttachment: fileAttachment,
            fileUri: fileUri,
+           fileExpirationTime: fileExpirationTime,
          ),
        ) {
     on<StudyChunkRequested>(_onStudyChunkRequested);
@@ -89,11 +92,13 @@ class StudyExecutionBloc
     String? documentSummary, {
     AiFileAttachment? fileAttachment,
     String? fileUri,
+    DateTime? fileExpirationTime,
   }) {
     var state = StudyExecutionState(
       chunks: chunks,
       fileAttachment: fileAttachment,
       fileUri: fileUri,
+      fileExpirationTime: fileExpirationTime,
       documentTitle: documentTitle,
       documentSummary: documentSummary,
     );
@@ -142,17 +147,29 @@ class StudyExecutionBloc
     chunksProcessing[event.chunkIndex] = processingChunk;
     emit(state.copyWith(chunks: chunksProcessing));
 
-    // Ensure we have a fileUri (multimodal File API upload)
     String? fileUri = state.fileUri;
+    DateTime? fileExpirationTime = state.fileExpirationTime;
     String? fileMimeType = state.fileAttachment?.mimeType;
 
-    if (fileUri == null && state.fileAttachment != null) {
-      try {
-        fileUri = await ServiceLocator.getIt<GeminiService>().uploadFile(
-          state.fileAttachment!,
-          _localizations,
+    // Check if file is expired (with 10-minute buffer)
+    final bool isExpired =
+        fileExpirationTime != null &&
+        DateTime.now().add(const Duration(minutes: 10)).isAfter(
+          fileExpirationTime,
         );
-        emit(state.copyWith(fileUri: fileUri));
+
+    if ((fileUri == null || isExpired) && state.fileAttachment != null) {
+      try {
+        final uploadResult = await ServiceLocator.getIt<GeminiService>()
+            .uploadFile(state.fileAttachment!, _localizations);
+        fileUri = uploadResult.fileUri;
+        fileExpirationTime = uploadResult.expirationTime;
+        emit(
+          state.copyWith(
+            fileUri: fileUri,
+            fileExpirationTime: fileExpirationTime,
+          ),
+        );
       } catch (e) {
         final errorChunk = chunk.copyWith(status: StudyChunkState.error);
         final chunksError = List<StudyChunk>.from(state.chunks);
@@ -162,7 +179,9 @@ class StudyExecutionBloc
       }
     }
 
-    if (fileUri == null && _originalText == null && !event.allowFallback) {
+    if ((fileUri == null || isExpired) &&
+        _originalText == null &&
+        !event.allowFallback) {
       if (state.fileAttachment != null) {
         // Revert chunk back to created — the user needs to re-attach the file
         final revertedChunk = chunk.copyWith(status: StudyChunkState.created);
@@ -203,6 +222,7 @@ class StudyExecutionBloc
       newState.processedChunks,
       newState.chunks,
       newState.fileUri,
+      newState.fileExpirationTime,
     );
   }
 
@@ -271,6 +291,7 @@ class StudyExecutionBloc
       newState.processedChunks,
       newState.chunks,
       newState.fileUri,
+      newState.fileExpirationTime,
     );
   }
 

--- a/lib/presentation/blocs/study_execution_bloc/study_execution_state.dart
+++ b/lib/presentation/blocs/study_execution_bloc/study_execution_state.dart
@@ -22,6 +22,7 @@ class StudyExecutionState {
   final int currentChunkIndex;
   final AiFileAttachment? fileAttachment;
   final String? fileUri;
+  final DateTime? fileExpirationTime;
   final String documentTitle;
   final String? documentSummary;
   final bool isLoading;
@@ -36,6 +37,7 @@ class StudyExecutionState {
     this.currentChunkIndex = 0,
     this.fileAttachment,
     this.fileUri,
+    this.fileExpirationTime,
     this.documentTitle = '',
     this.documentSummary,
     this.isLoading = false,
@@ -51,6 +53,7 @@ class StudyExecutionState {
     int? currentChunkIndex,
     AiFileAttachment? fileAttachment,
     String? fileUri,
+    DateTime? fileExpirationTime,
     String? documentTitle,
     String? documentSummary,
     bool? isLoading,
@@ -65,6 +68,7 @@ class StudyExecutionState {
       currentChunkIndex: currentChunkIndex ?? this.currentChunkIndex,
       fileAttachment: fileAttachment ?? this.fileAttachment,
       fileUri: fileUri ?? this.fileUri,
+      fileExpirationTime: fileExpirationTime ?? this.fileExpirationTime,
       documentTitle: documentTitle ?? this.documentTitle,
       documentSummary: documentSummary ?? this.documentSummary,
       isLoading: isLoading ?? this.isLoading,
@@ -102,6 +106,7 @@ class StudyExecutionState {
         other.currentChunkIndex == currentChunkIndex &&
         other.fileAttachment == fileAttachment &&
         other.fileUri == fileUri &&
+        other.fileExpirationTime == fileExpirationTime &&
         other.documentTitle == documentTitle &&
         other.documentSummary == documentSummary &&
         other.isLoading == isLoading &&
@@ -118,6 +123,7 @@ class StudyExecutionState {
         currentChunkIndex.hashCode ^
         fileAttachment.hashCode ^
         fileUri.hashCode ^
+        fileExpirationTime.hashCode ^
         documentTitle.hashCode ^
         documentSummary.hashCode ^
         isLoading.hashCode ^

--- a/lib/presentation/screens/study_screen.dart
+++ b/lib/presentation/screens/study_screen.dart
@@ -91,6 +91,7 @@ class StudyScreen extends StatelessWidget {
         initialChunks: initialChunks,
         fileAttachment: fileAttachment ?? quizFile?.fileAttachment,
         fileUri: quizFile?.fileUri,
+        fileExpirationTime: quizFile?.fileExpirationTime,
         documentTitle: documentTitle,
         documentSummary: documentSummary ?? quizFile?.metadata.description,
         isAutoDifficulty: quizFile?.study?.isAutoDifficulty ?? isAutoDifficulty,
@@ -98,13 +99,15 @@ class StudyScreen extends StatelessWidget {
         originalText: originalText ?? quizFile?.study?.originalText,
         language: language ?? quizFile?.study?.language,
         generationMode: generationMode ?? quizFile?.study?.generationMode,
-        onProgressChanged: (progress, processedChunks, chunks, fileUri) {
+        onProgressChanged:
+            (progress, processedChunks, chunks, fileUri, expirationTime) {
           context.read<FileBloc>().add(
             StudyProgressUpdated(
               progress: progress,
               processedChunks: processedChunks,
               chunks: chunks,
               fileUri: fileUri,
+              fileExpirationTime: expirationTime,
             ),
           );
         },
@@ -165,6 +168,7 @@ class _StudyScreenViewState extends State<StudyScreenView> {
 
       return qf.copyWith(
         fileUri: studyState.fileUri,
+        fileExpirationTime: studyState.fileExpirationTime,
         fileContentHash:
             qf.fileContentHash ?? studyState.fileAttachment?.contentHash,
         study:
@@ -204,6 +208,7 @@ class _StudyScreenViewState extends State<StudyScreenView> {
         ),
         fileContentHash: studyState.fileAttachment?.contentHash,
         fileUri: studyState.fileUri,
+        fileExpirationTime: studyState.fileExpirationTime,
       );
     }
   }


### PR DESCRIPTION
## Summary
- Added `fileExpirationTime` to `QuizFile` model and `StudyExecutionState` for persistent tracking of file validity.
- Updated `GeminiService` to parse and return the `expirationTime` directly from the Gemini File API response.
- Implemented automatic file re-upload logic in `StudyExecutionBloc` to handle the 48-hour expiration limit seamlessly.
- Added a 10-minute safety buffer to prevent race conditions during expiration checks.
- Updated the study progress persistence flow to ensure `fileUri` and `fileExpirationTime` are updated in the `.quiz` file after a re-upload.

Fixes #214