### PR TITLE
Fix: Allow saving settings when AI is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.2]
+## [1.9.0]
 
 - feat: Added section import from .quiz files in Study Mode index view, with position selection dialog (beginning/end) and drag & drop support.
 - i18n: Added 5 new languages (Russian, Ukrainian, Georgian, Korean, and Greek) to the supported list, bringing the total to 18.
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Added "Paste" button to API key text fields in settings for quicker setup.
 - fix: AI Generation dialog now properly saves and restores attached file paths across sessions.
 - feat: Enhanced Study Mode with just-in-time AI content generation, lazy loading of chapters, and robust handling of large PDF/document files for a seamless learning experience.
+- fix: Allow saving settings even when the AI Assistant is disabled and no API keys are provided.
 - feat: Seamless cross-mode navigation between Quiz and Study screens, preserving the back-stack so pressing Back returns to the previous mode.
 
 ## [1.8.1] - 2026-02-26

--- a/lib/presentation/screens/dialogs/settings_dialog.dart
+++ b/lib/presentation/screens/dialogs/settings_dialog.dart
@@ -101,7 +101,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
     final hasValidOpenAI = apiKey.isValidOpenAIApiKey;
     final hasValidGemini = geminiApiKey.isValidGeminiApiKey;
 
-    if (!hasValidOpenAI && !hasValidGemini) {
+    if (_aiAssistantEnabled && !hasValidOpenAI && !hasValidGemini) {
       setState(() {
         _apiKeyErrorMessage = AppLocalizations.of(
           context,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.8.2+23
+version: 1.9.0+23
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
This PR fixes a bug where the settings dialog required API keys even when the AI Assistant was disabled. It also includes the version bump to 1.9.0.

### Changes:
- Modified `SettingsDialog._saveSettings` to skip API key validation when `_aiAssistantEnabled` is false.
- Updated `CHANGELOG.md` and `pubspec.yaml` for version 1.9.0.

Closes https://github.com/vicajilau/quizdy/issues/262