### PR TITLE
Fix study chunk and quiz question tags not clearing on save

### DIFF
--- a/lib/data/repositories/quiz_file_repository.dart
+++ b/lib/data/repositories/quiz_file_repository.dart
@@ -75,7 +75,7 @@ class QuizFileRepository {
       questions: questions ?? [], // Start with empty questions or provided ones
     );
 
-    ServiceLocator.registerQuizFile(quizFile);
+    registerQuizFile(quizFile);
     return quizFile;
   }
 

--- a/lib/presentation/screens/widgets/question_list_widget.dart
+++ b/lib/presentation/screens/widgets/question_list_widget.dart
@@ -14,12 +14,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:quizdy/core/context_extension.dart';
 import 'package:quizdy/core/service_locator.dart';
 import 'package:quizdy/domain/models/quiz/question.dart';
 import 'package:quizdy/domain/models/quiz/quiz_file.dart';
 import 'package:quizdy/domain/use_cases/check_file_changes_use_case.dart';
+import 'package:quizdy/presentation/blocs/file_bloc/file_bloc.dart';
 import 'package:quizdy/presentation/screens/dialogs/add_edit_question_dialog.dart';
 import 'package:quizdy/presentation/screens/dialogs/ai_question_dialog.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
@@ -69,6 +71,9 @@ class _QuestionListWidgetState extends State<QuestionListWidget> {
 
   @override
   Widget build(BuildContext context) {
+    // Watch FileBloc to trigger rebuild (and re-evaluate tags) when file is saved
+    context.watch<FileBloc>();
+
     return ReorderableListView.builder(
       onReorder: _onReorder,
       padding: const EdgeInsets.symmetric(horizontal: 8.0).copyWith(top: 24),

--- a/lib/presentation/screens/widgets/study/study_index_view.dart
+++ b/lib/presentation/screens/widgets/study/study_index_view.dart
@@ -21,6 +21,7 @@ import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/core/service_locator.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
 import 'package:quizdy/domain/use_cases/check_file_changes_use_case.dart';
+import 'package:quizdy/presentation/blocs/file_bloc/file_bloc.dart';
 import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_bloc.dart';
 import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_event.dart';
 import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_state.dart';
@@ -68,6 +69,9 @@ class StudyIndexView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Watch FileBloc to trigger rebuild (and re-evaluate tags) when file is saved
+    context.watch<FileBloc>();
+
     return Padding(
       padding: EdgeInsets.only(
         top: MediaQuery.of(context).padding.top,

--- a/lib/presentation/screens/widgets/study/study_sections_sidebar.dart
+++ b/lib/presentation/screens/widgets/study/study_sections_sidebar.dart
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/core/service_locator.dart';
@@ -21,6 +22,7 @@ import 'package:quizdy/core/theme/app_theme.dart';
 import 'package:quizdy/domain/models/quiz/study_chunk.dart';
 import 'package:quizdy/domain/models/quiz/study_chunk_state.dart';
 import 'package:quizdy/domain/use_cases/check_file_changes_use_case.dart';
+import 'package:quizdy/presentation/blocs/file_bloc/file_bloc.dart';
 
 class StudySectionsSidebar extends StatelessWidget {
   final List<StudyChunk> chunks;
@@ -54,6 +56,9 @@ class StudySectionsSidebar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Watch FileBloc to trigger rebuild (and re-evaluate tags) when file is saved
+    context.watch<FileBloc>();
+    
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return Container(


### PR DESCRIPTION
## Summary
- Fixed `originalFile` initialization in `QuizFileRepository.createQuizFile` so that newly created study chunks are correctly identified as NEW instead of MODIFIED.
- Added `context.watch<FileBloc>()` to `QuestionListWidget`, `StudyIndexView`, and `StudySectionsSidebar` to ensure that the NEW/MODIFIED tag banners disappear immediately upon saving.