### PR TITLE
Add exit confirmation dialog when there are unsaved changes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:quizdy/core/quizdy_bloc_observer.dart';
 import 'package:quizdy/routes/app_router.dart';
@@ -22,11 +23,15 @@ import 'package:quizdy/core/theme/app_theme.dart';
 import 'package:quizdy/core/file_handler.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/core/service_locator.dart';
+import 'package:quizdy/domain/use_cases/check_file_changes_use_case.dart';
 import 'package:quizdy/presentation/blocs/file_bloc/file_bloc.dart';
+import 'package:quizdy/presentation/blocs/file_bloc/file_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:quizdy/presentation/blocs/file_bloc/file_event.dart';
 import 'package:quizdy/presentation/blocs/locale_cubit/locale_cubit.dart';
 import 'package:quizdy/presentation/blocs/locale_cubit/locale_state.dart';
+import 'package:quizdy/presentation/screens/dialogs/exit_confirmation_dialog.dart';
+import 'package:quizdy/domain/models/quiz/quiz_file.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -46,16 +51,59 @@ class QuizApplication extends StatefulWidget {
   State<QuizApplication> createState() => _QuizApplicationState();
 }
 
-class _QuizApplicationState extends State<QuizApplication> {
+class _QuizApplicationState extends State<QuizApplication> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     FileHandler.initialize((filePath) {
       if (mounted) {
         final fileBloc = ServiceLocator.getIt<FileBloc>();
         fileBloc.add(FileDropped(filePath));
       }
     });
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  Future<AppExitResponse> didRequestAppExit() async {
+    final fileBloc = ServiceLocator.getIt<FileBloc>();
+    final state = fileBloc.state;
+
+    QuizFile? currentFile;
+    if (state is FileLoaded) {
+      currentFile = state.quizFile;
+    } else if (state is FileSaved) {
+      currentFile = state.quizFile;
+    }
+
+    if (currentFile != null) {
+      final checkFileChangesUseCase =
+          ServiceLocator.getIt<CheckFileChangesUseCase>();
+      final hasChanges = checkFileChangesUseCase.execute(currentFile);
+
+      if (hasChanges) {
+        // Find the navigator context to show the dialog
+        final context = rootNavigatorKey.currentContext;
+        if (context != null) {
+          final shouldExit = await showDialog<bool>(
+            context: context,
+            builder: (context) => const ExitConfirmationDialog(),
+          );
+
+          if (shouldExit != true) {
+            return AppExitResponse.cancel;
+          }
+        }
+      }
+    }
+
+    return AppExitResponse.exit;
   }
 
   @override

--- a/lib/presentation/blocs/file_bloc/file_bloc.dart
+++ b/lib/presentation/blocs/file_bloc/file_bloc.dart
@@ -246,5 +246,13 @@ class FileBloc extends Bloc<FileEvent, FileState> {
         }
       }
     });
+    on<QuizFileUpdated>((event, emit) {
+      _fileRepository.updateActiveQuizFile(event.quizFile);
+      if (state is FileLoaded) {
+        emit(FileLoaded(event.quizFile));
+      } else if (state is FileSaved) {
+        emit(FileSaved(event.quizFile));
+      }
+    });
   }
 }

--- a/lib/presentation/blocs/file_bloc/file_event.dart
+++ b/lib/presentation/blocs/file_bloc/file_event.dart
@@ -102,6 +102,11 @@ class StudyProgressUpdated extends FileEvent {
   });
 }
 
+/// Event triggered to update the active quiz file without saving to disk.
+class QuizFileUpdated extends FileEvent {
+  final QuizFile quizFile;
+  QuizFileUpdated(this.quizFile);
+}
+
 /// Event triggered to reset the file state.
-/// This event can be used to clear any file-related data or state.
 class QuizFileReset extends FileEvent {}

--- a/lib/presentation/screens/quiz_loaded_screen.dart
+++ b/lib/presentation/screens/quiz_loaded_screen.dart
@@ -75,6 +75,10 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
   final Set<int> _selectedQuestions = {};
   bool _isDragging = false;
 
+  void _syncQuizFileToBloc() {
+    context.read<FileBloc>().add(QuizFileUpdated(cachedQuizFile));
+  }
+
   Future<bool> _confirmExit() async {
     if (widget.checkFileChangesUseCase.execute(cachedQuizFile)) {
       return await showDialog<bool>(
@@ -403,6 +407,7 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
         cachedQuizFile = cachedQuizFile.copyWith(questions: updatedQuestions);
         _selectedQuestions.clear();
       });
+      _syncQuizFileToBloc();
     }
   }
 
@@ -562,6 +567,7 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
                                                   ),
                                             );
                                       });
+                                      _syncQuizFileToBloc();
                                     }
                                   },
                                   child: Text(
@@ -715,7 +721,10 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
                         padding: const EdgeInsets.symmetric(horizontal: 24.0),
                         child: QuestionListWidget(
                           quizFile: cachedQuizFile,
-                          onFileChange: () => setState(() {}),
+                          onFileChange: () {
+                            setState(() {});
+                            _syncQuizFileToBloc();
+                          },
                           isSelectionMode: _isSelectionMode,
                           selectedQuestions: _selectedQuestions,
                           onToggleSelection: _toggleQuestionSelection,

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:quizdy/core/debug_print.dart';
 import 'package:quizdy/domain/models/quiz/quiz_file.dart';
@@ -31,6 +32,8 @@ import 'package:quizdy/presentation/screens/home_screen.dart';
 import 'package:quizdy/presentation/screens/onboarding/onboarding_screen.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
 
+final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>();
+
 class AppRoutes {
   static const String home = '/';
   static const String onboarding = '/onboarding';
@@ -40,6 +43,7 @@ class AppRoutes {
 }
 
 GoRouter buildAppRouter({required bool showOnboarding}) => GoRouter(
+  navigatorKey: rootNavigatorKey,
   initialLocation: showOnboarding ? AppRoutes.onboarding : AppRoutes.home,
   routes: [
     GoRoute(


### PR DESCRIPTION
## Summary
- Added `didRequestAppExit` in `_QuizApplicationState` to intercept window close requests
- Added global `rootNavigatorKey` to access context for dialogs above the router
- Added `QuizFileUpdated` event to keep `FileBloc` synced with local UI changes
- Sync `QuizFile` to bloc from `QuizLoadedScreen` when modifications occur

Fixes #269