### PR TITLE
fix: navigate allways to `QuizLoadedScreen` if you are generating questions with AI

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -196,6 +196,7 @@ class _HomeScreenState extends State<HomeScreen> {
           final unknownValue = AppLocalizations.of(
             context,
           )!.questionTypeUnknown;
+          setState(() => _pendingDropMode = QuizMode.quiz);
           context.read<FileBloc>().add(
             CreateQuizWithQuestions(
               name: unknownValue,


### PR DESCRIPTION
fix: navigate allways to QuizLoadedScreen if you are generating questions with AI
