### PR TITLE
refactor(ui): unify app bars with QuizdyAppBar

### DIFF
--- a/lib/presentation/screens/privacy_policy/privacy_policy_screen.dart
+++ b/lib/presentation/screens/privacy_policy/privacy_policy_screen.dart
@@ -20,6 +20,7 @@ import 'package:quizdy/core/context_extension.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/core/service_locator.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
+import 'package:quizdy/presentation/screens/widgets/common/quizdy_app_bar.dart';
 import 'package:quizdy/presentation/screens/widgets/common/markdown_widget.dart';
 import 'package:quizdy/presentation/widgets/quizdy_button.dart';
 import 'package:quizdy/routes/app_router.dart';
@@ -127,9 +128,18 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
     return PopScope(
       canPop: canPopScreen,
       child: Scaffold(
-        appBar: AppBar(
-          automaticallyImplyLeading: canPopScreen,
-          title: Text(localizations.privacyPolicyLabel),
+        appBar: QuizdyAppBar(
+          showLeading: canPopScreen,
+          onLeadingPressed: _closeScreen,
+          title: Text(
+            localizations.privacyPolicyLabel,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onPrimary,
+              fontSize: 20,
+              fontWeight: FontWeight.w700,
+              fontFamily: 'Plus Jakarta Sans',
+            ),
+          ),
         ),
         body: SafeArea(
           child: Padding(

--- a/lib/presentation/screens/quiz_loaded_screen.dart
+++ b/lib/presentation/screens/quiz_loaded_screen.dart
@@ -47,6 +47,7 @@ import 'package:quizdy/domain/models/ai/ai_generation_config.dart';
 import 'package:quizdy/presentation/screens/dialogs/ai_generate_questions_dialog.dart';
 import 'package:quizdy/presentation/screens/widgets/quiz_loaded_bottom_bar.dart';
 import 'package:quizdy/presentation/screens/dialogs/settings_dialog.dart';
+import 'package:quizdy/presentation/screens/widgets/common/quizdy_app_bar.dart';
 import 'package:quizdy/presentation/screens/widgets/request_file_name_dialog.dart';
 import 'package:quizdy/presentation/widgets/empty_state_view.dart';
 import 'package:quizdy/data/services/ai/ai_question_generation_service.dart';
@@ -477,175 +478,222 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
           child: Builder(
             builder: (context) {
               return Scaffold(
-                appBar: PreferredSize(
-                  preferredSize: const Size.fromHeight(72),
-                  child: AppBar(
-                    backgroundColor: Theme.of(context).primaryColor,
-                    elevation: 0,
-                    shape: const RoundedRectangleBorder(
-                      borderRadius: BorderRadius.vertical(
-                        bottom: Radius.circular(24),
-                      ),
-                    ),
-                    toolbarHeight: 72,
-                    leadingWidth: 72,
-                    leading: Padding(
-                      padding: const EdgeInsets.only(left: 24),
-                      child: Center(
-                        child: Container(
-                          width: 40,
-                          height: 40,
-                          decoration: BoxDecoration(
-                            color: context
-                                .quizLoadedTheme
-                                .appBarIconBackgroundColor,
-                            borderRadius: BorderRadius.circular(20),
-                          ),
-                          child: IconButton(
-                            padding: EdgeInsets.zero,
-                            icon: Icon(
-                              LucideIcons.arrowLeft,
-                              color: Theme.of(context).colorScheme.onPrimary,
-                              size: 20,
+                appBar: QuizdyAppBar(
+                  onLeadingPressed: () async {
+                    final shouldExit = await _confirmExit();
+                    if (shouldExit && context.mounted) {
+                      if (context.canPop()) {
+                        context.pop();
+                      } else {
+                        context.go(AppRoutes.home);
+                      }
+                    }
+                  },
+                  title: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Flexible(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            MouseRegion(
+                              cursor: SystemMouseCursors.click,
+                              child: GestureDetector(
+                                onTap: () async {
+                                  final result =
+                                      await showDialog<Map<String, String>>(
+                                        context: context,
+                                        builder: (context) =>
+                                            QuizMetadataDialog(
+                                              isEditing: true,
+                                              initialName:
+                                                  cachedQuizFile.metadata.title,
+                                              initialDescription: cachedQuizFile
+                                                  .metadata
+                                                  .description,
+                                              initialAuthor: cachedQuizFile
+                                                  .metadata
+                                                  .author,
+                                            ),
+                                      );
+
+                                  if (result != null && mounted) {
+                                    setState(() {
+                                      cachedQuizFile = cachedQuizFile.copyWith(
+                                        metadata: cachedQuizFile.metadata
+                                            .copyWith(
+                                              title: result['name'],
+                                              description:
+                                                  result['description'],
+                                              author: result['author'],
+                                            ),
+                                      );
+                                    });
+                                    _syncQuizFileToBloc();
+                                  }
+                                },
+                                child: Text(
+                                  AppLocalizations.of(
+                                    context,
+                                  )!.quizPreviewTitle,
+                                  style: TextStyle(
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onPrimary,
+                                    fontSize: 20,
+                                    fontWeight: FontWeight.w700,
+                                    fontFamily: 'Plus Jakarta Sans',
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
                             ),
-                            tooltip: AppLocalizations.of(
-                              context,
-                            )!.backSemanticLabel,
-                            onPressed: () async {
-                              final shouldExit = await _confirmExit();
-                              if (shouldExit && context.mounted) {
-                                if (context.canPop()) {
-                                  context.pop();
-                                } else {
-                                  context.go(AppRoutes.home);
-                                }
-                              }
-                            },
-                          ),
+                          ],
                         ),
                       ),
-                    ),
-                    title: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Flexible(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              MouseRegion(
-                                cursor: SystemMouseCursors.click,
-                                child: GestureDetector(
-                                  onTap: () async {
-                                    final result =
-                                        await showDialog<Map<String, String>>(
-                                          context: context,
-                                          builder: (context) =>
-                                              QuizMetadataDialog(
-                                                isEditing: true,
-                                                initialName: cachedQuizFile
-                                                    .metadata
-                                                    .title,
-                                                initialDescription:
-                                                    cachedQuizFile
-                                                        .metadata
-                                                        .description,
-                                                initialAuthor: cachedQuizFile
-                                                    .metadata
-                                                    .author,
-                                              ),
-                                        );
-
-                                    if (result != null && mounted) {
-                                      setState(() {
-                                        cachedQuizFile = cachedQuizFile
-                                            .copyWith(
-                                              metadata: cachedQuizFile.metadata
-                                                  .copyWith(
-                                                    title: result['name'],
-                                                    description:
-                                                        result['description'],
-                                                    author: result['author'],
-                                                  ),
-                                            );
-                                      });
-                                      _syncQuizFileToBloc();
-                                    }
-                                  },
-                                  child: Text(
-                                    AppLocalizations.of(
-                                      context,
-                                    )!.quizPreviewTitle,
-                                    style: TextStyle(
+                    ],
+                  ),
+                  actions: [
+                    // Study Mode Button
+                    Container(
+                      margin: const EdgeInsets.only(right: 8),
+                      constraints: const BoxConstraints(minWidth: 40),
+                      child: Material(
+                        color:
+                            context.quizLoadedTheme.appBarIconBackgroundColor,
+                        borderRadius: BorderRadius.circular(20),
+                        child: InkWell(
+                          borderRadius: BorderRadius.circular(20),
+                          onTap: () {
+                            context.push(
+                              AppRoutes.studyScreen,
+                              extra: {
+                                'initialChunks':
+                                    widget.quizFile.study!.content.cache,
+                                'documentTitle': widget.quizFile.metadata.title,
+                                'documentSummary':
+                                    widget.quizFile.metadata.description,
+                                'quizFile': widget.quizFile,
+                                'hideStartQuizButton': true,
+                              },
+                            );
+                          },
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 10,
+                            ),
+                            child: Builder(
+                              builder: (context) {
+                                final showText =
+                                    MediaQuery.of(context).size.width > 500;
+                                return Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Icon(
+                                      LucideIcons.bookOpen,
                                       color: Theme.of(
                                         context,
                                       ).colorScheme.onPrimary,
-                                      fontSize: 20,
-                                      fontWeight: FontWeight.w700,
-                                      fontFamily: 'Plus Jakarta Sans',
+                                      size: 18,
                                     ),
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                ),
-                              ),
-                            ],
+                                    if (showText) ...[
+                                      const SizedBox(width: 6),
+                                      Text(
+                                        AppLocalizations.of(
+                                          context,
+                                        )!.studyModeLabel,
+                                        style: TextStyle(
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.onPrimary,
+                                          fontSize: 13,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ],
+                                  ],
+                                );
+                              },
+                            ),
                           ),
                         ),
-                      ],
+                      ),
                     ),
-                    actions: [
-                      // Study Mode Button
-                      Container(
-                        margin: const EdgeInsets.only(right: 8),
-                        constraints: const BoxConstraints(minWidth: 40),
-                        child: Material(
-                          color:
-                              context.quizLoadedTheme.appBarIconBackgroundColor,
-                          borderRadius: BorderRadius.circular(20),
-                          child: InkWell(
-                            borderRadius: BorderRadius.circular(20),
-                            onTap: () {
-                              context.push(
-                                AppRoutes.studyScreen,
-                                extra: {
-                                  'initialChunks':
-                                      widget.quizFile.study!.content.cache,
-                                  'documentTitle':
-                                      widget.quizFile.metadata.title,
-                                  'documentSummary':
-                                      widget.quizFile.metadata.description,
-                                  'quizFile': widget.quizFile,
-                                  'hideStartQuizButton': true,
-                                },
-                              );
-                            },
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 10,
-                              ),
-                              child: Builder(
-                                builder: (context) {
-                                  final showText =
-                                      MediaQuery.of(context).size.width > 500;
-                                  return Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Icon(
-                                        LucideIcons.bookOpen,
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.onPrimary,
-                                        size: 18,
-                                      ),
-                                      if (showText) ...[
-                                        const SizedBox(width: 6),
-                                        Text(
-                                          AppLocalizations.of(
-                                            context,
-                                          )!.studyModeLabel,
+                    // Settings Button
+                    Container(
+                      width: 40,
+                      height: 40,
+                      margin: const EdgeInsets.only(right: 8),
+                      decoration: BoxDecoration(
+                        color:
+                            context.quizLoadedTheme.appBarIconBackgroundColor,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: IconButton(
+                        padding: EdgeInsets.zero,
+                        onPressed: () => _showSettingsDialog(context),
+                        icon: Icon(
+                          LucideIcons.settings,
+                          color: Theme.of(context).colorScheme.onPrimary,
+                          size: 20,
+                        ),
+                        tooltip: AppLocalizations.of(
+                          context,
+                        )!.questionOrderConfigTooltip,
+                      ),
+                    ),
+                    Container(
+                      margin: const EdgeInsets.only(right: 24),
+                      constraints: const BoxConstraints(minWidth: 40),
+                      child: Material(
+                        color: context
+                            .quizLoadedTheme
+                            .selectionInactiveBackgroundColor,
+                        borderRadius: BorderRadius.circular(12),
+                        child: InkWell(
+                          borderRadius: BorderRadius.circular(12),
+                          onTap: () {
+                            _toggleSelectionMode();
+                          },
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 10,
+                            ),
+                            child: Builder(
+                              builder: (context) {
+                                final showText =
+                                    MediaQuery.of(context).size.width > 500;
+
+                                return Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Icon(
+                                      _isSelectionMode
+                                          ? LucideIcons.checkSquare
+                                          : LucideIcons.mousePointer2,
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.onPrimary,
+                                      size: 18,
+                                    ),
+                                    if (showText) ...[
+                                      const SizedBox(width: 8),
+                                      Flexible(
+                                        child: Text(
+                                          _isSelectionMode
+                                              ? AppLocalizations.of(
+                                                  context,
+                                                )!.done
+                                              : AppLocalizations.of(
+                                                  context,
+                                                )!.select,
                                           style: TextStyle(
                                             color: Theme.of(
                                               context,
@@ -655,106 +703,17 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
                                           ),
                                           overflow: TextOverflow.ellipsis,
                                         ),
-                                      ],
-                                    ],
-                                  );
-                                },
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                      // Settings Button
-                      Container(
-                        width: 40,
-                        height: 40,
-                        margin: const EdgeInsets.only(right: 8),
-                        decoration: BoxDecoration(
-                          color:
-                              context.quizLoadedTheme.appBarIconBackgroundColor,
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: IconButton(
-                          padding: EdgeInsets.zero,
-                          onPressed: () => _showSettingsDialog(context),
-                          icon: Icon(
-                            LucideIcons.settings,
-                            color: Theme.of(context).colorScheme.onPrimary,
-                            size: 20,
-                          ),
-                          tooltip: AppLocalizations.of(
-                            context,
-                          )!.questionOrderConfigTooltip,
-                        ),
-                      ),
-                      Container(
-                        margin: const EdgeInsets.only(right: 24),
-                        constraints: const BoxConstraints(minWidth: 40),
-                        child: Material(
-                          color: context
-                              .quizLoadedTheme
-                              .selectionInactiveBackgroundColor,
-                          borderRadius: BorderRadius.circular(12),
-                          child: InkWell(
-                            borderRadius: BorderRadius.circular(12),
-                            onTap: () {
-                              _toggleSelectionMode();
-                            },
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 10,
-                              ),
-                              child: Builder(
-                                builder: (context) {
-                                  final showText =
-                                      MediaQuery.of(context).size.width > 500;
-
-                                  return Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Icon(
-                                        _isSelectionMode
-                                            ? LucideIcons.checkSquare
-                                            : LucideIcons.mousePointer2,
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.onPrimary,
-                                        size: 18,
                                       ),
-                                      if (showText) ...[
-                                        const SizedBox(width: 8),
-                                        Flexible(
-                                          child: Text(
-                                            _isSelectionMode
-                                                ? AppLocalizations.of(
-                                                    context,
-                                                  )!.done
-                                                : AppLocalizations.of(
-                                                    context,
-                                                  )!.select,
-                                            style: TextStyle(
-                                              color: Theme.of(
-                                                context,
-                                              ).colorScheme.onPrimary,
-                                              fontSize: 13,
-                                              fontWeight: FontWeight.w600,
-                                            ),
-                                            overflow: TextOverflow.ellipsis,
-                                          ),
-                                        ),
-                                      ],
                                     ],
-                                  );
-                                },
-                              ),
+                                  ],
+                                );
+                              },
                             ),
                           ),
                         ),
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
                 body: DropTarget(
                   onDragDone: (details) {

--- a/lib/presentation/screens/study_editor/component_editor_screen.dart
+++ b/lib/presentation/screens/study_editor/component_editor_screen.dart
@@ -26,6 +26,7 @@ import 'package:quizdy/presentation/blocs/study_editor_cubit/study_editor_state.
 import 'package:quizdy/presentation/screens/study_editor/add_component_sheet.dart';
 import 'package:quizdy/presentation/screens/study_editor/component_card.dart';
 import 'package:quizdy/presentation/screens/study_editor/component_edit_sidebar.dart';
+import 'package:quizdy/presentation/screens/widgets/common/quizdy_app_bar.dart';
 import 'package:quizdy/presentation/widgets/quizdy_button.dart';
 
 /// Shows the list of [StudyComponent]s on a single page within a section.
@@ -217,38 +218,8 @@ class _ComponentEditorScreenState extends State<ComponentEditorScreen>
         return Scaffold(
           appBar: showMobileOverlay
               ? null
-              : AppBar(
-                  backgroundColor: Theme.of(context).primaryColor,
-                  elevation: 0,
-                  shape: const RoundedRectangleBorder(
-                    borderRadius: BorderRadius.vertical(
-                      bottom: Radius.circular(24),
-                    ),
-                  ),
-                  toolbarHeight: 72,
-                  leadingWidth: 72,
-                  leading: Padding(
-                    padding: const EdgeInsets.only(left: 24),
-                    child: Center(
-                      child: Container(
-                        width: 40,
-                        height: 40,
-                        decoration: BoxDecoration(
-                          color: AppTheme.appBarIconBackground,
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: IconButton(
-                          padding: EdgeInsets.zero,
-                          icon: Icon(
-                            LucideIcons.arrowLeft,
-                            color: Theme.of(context).colorScheme.onPrimary,
-                            size: 20,
-                          ),
-                          onPressed: () => context.pop(false),
-                        ),
-                      ),
-                    ),
-                  ),
+              : QuizdyAppBar(
+                  onLeadingPressed: () => context.pop(false),
                   title: Text(
                     chunk.title,
                     style: TextStyle(

--- a/lib/presentation/screens/study_editor/paragraph_property_panel.dart
+++ b/lib/presentation/screens/study_editor/paragraph_property_panel.dart
@@ -15,10 +15,10 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lucide_icons/lucide_icons.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/domain/models/quiz/study_component.dart';
 import 'package:quizdy/presentation/blocs/study_editor_cubit/study_editor_cubit.dart';
+import 'package:quizdy/presentation/screens/widgets/common/quizdy_app_bar.dart';
 import 'package:quizdy/presentation/widgets/quizdy_button.dart';
 import 'package:quizdy/presentation/widgets/quizdy_text_field.dart';
 
@@ -86,13 +86,18 @@ class _ParagraphPropertyPanelState extends State<ParagraphPropertyPanel> {
     final localizations = AppLocalizations.of(context)!;
 
     return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(LucideIcons.arrowLeft),
-          onPressed: () => Navigator.of(context).pop(),
+      appBar: QuizdyAppBar(
+        onLeadingPressed: () => Navigator.of(context).pop(),
+        title: Text(
+          localizations.studyEditorEditParagraph,
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onPrimary,
+            fontSize: 20,
+            fontWeight: FontWeight.w700,
+            fontFamily: 'Plus Jakarta Sans',
+          ),
+          overflow: TextOverflow.ellipsis,
         ),
-        title: Text(localizations.studyEditorEditParagraph),
-        elevation: 0,
       ),
       body: Column(
         children: [

--- a/lib/presentation/screens/study_editor/section_page_manager_screen.dart
+++ b/lib/presentation/screens/study_editor/section_page_manager_screen.dart
@@ -21,6 +21,7 @@ import 'package:quizdy/domain/models/quiz/study_page.dart';
 import 'package:quizdy/presentation/blocs/study_editor_cubit/study_editor_cubit.dart';
 import 'package:quizdy/presentation/blocs/study_editor_cubit/study_editor_state.dart';
 import 'package:quizdy/presentation/screens/study_editor/component_editor_screen.dart';
+import 'package:quizdy/presentation/screens/widgets/common/quizdy_app_bar.dart';
 import 'package:quizdy/presentation/widgets/quizdy_button.dart';
 
 /// Manages the list of pages within a study section (chunk).
@@ -80,13 +81,18 @@ class SectionPageManagerScreen extends StatelessWidget {
         final pages = chunk.pages;
 
         return Scaffold(
-          appBar: AppBar(
-            leading: IconButton(
-              icon: const Icon(LucideIcons.arrowLeft),
-              onPressed: () => Navigator.of(context).pop(),
+          appBar: QuizdyAppBar(
+            onLeadingPressed: () => Navigator.of(context).pop(),
+            title: Text(
+              localizations.studyEditorEditName(chunk.title),
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onPrimary,
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+                fontFamily: 'Plus Jakarta Sans',
+              ),
+              overflow: TextOverflow.ellipsis,
             ),
-            title: Text(localizations.studyEditorEditName(chunk.title)),
-            elevation: 0,
           ),
           body: pages.isEmpty
               ? Center(child: Text(localizations.studyEditorEmptyPages))

--- a/lib/presentation/screens/widgets/common/quizdy_app_bar.dart
+++ b/lib/presentation/screens/widgets/common/quizdy_app_bar.dart
@@ -1,0 +1,112 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+import 'package:quizdy/core/theme/extensions/quiz_loaded_theme.dart';
+
+class QuizdyAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final Widget title;
+  final List<Widget>? actions;
+  final bool showLeading;
+  final VoidCallback? onLeadingPressed;
+  final Widget? leading;
+  final String? leadingTooltip;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
+
+  const QuizdyAppBar({
+    super.key,
+    required this.title,
+    this.actions,
+    this.showLeading = true,
+    this.onLeadingPressed,
+    this.leading,
+    this.leadingTooltip,
+    this.backgroundColor,
+    this.foregroundColor,
+  });
+
+  @override
+  Size get preferredSize => const Size.fromHeight(72);
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context)!;
+    final resolvedForegroundColor =
+        foregroundColor ?? Theme.of(context).colorScheme.onPrimary;
+
+    return AppBar(
+      automaticallyImplyLeading: false,
+      backgroundColor: backgroundColor ?? Theme.of(context).primaryColor,
+      foregroundColor: resolvedForegroundColor,
+      elevation: 0,
+      scrolledUnderElevation: 0,
+      surfaceTintColor: Colors.transparent,
+      shadowColor: Colors.transparent,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(bottom: Radius.circular(24)),
+      ),
+      toolbarHeight: 72,
+      leadingWidth: showLeading ? 72 : null,
+      leading: showLeading
+          ? (leading ??
+                _DefaultLeadingButton(
+                  onPressed: onLeadingPressed,
+                  foregroundColor: resolvedForegroundColor,
+                  tooltip: leadingTooltip ?? localizations.backSemanticLabel,
+                ))
+          : null,
+      title: title,
+      actions: actions,
+    );
+  }
+}
+
+class _DefaultLeadingButton extends StatelessWidget {
+  final VoidCallback? onPressed;
+  final Color foregroundColor;
+  final String tooltip;
+
+  const _DefaultLeadingButton({
+    required this.onPressed,
+    required this.foregroundColor,
+    required this.tooltip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 24),
+      child: Center(
+        child: Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: context.quizLoadedTheme.appBarIconBackgroundColor,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: IconButton(
+            padding: EdgeInsets.zero,
+            icon: Icon(LucideIcons.arrowLeft, color: foregroundColor, size: 20),
+            tooltip: tooltip,
+            onPressed: onPressed,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/widgets/study/study_app_bar.dart
+++ b/lib/presentation/screens/widgets/study/study_app_bar.dart
@@ -24,6 +24,7 @@ import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_b
 import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_event.dart';
 import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_state.dart';
 import 'package:quizdy/presentation/screens/dialogs/settings_dialog.dart';
+import 'package:quizdy/presentation/screens/widgets/common/quizdy_app_bar.dart';
 
 class StudyAppBar extends StatelessWidget implements PreferredSizeWidget {
   final Future<bool> Function() onConfirmExit;
@@ -37,14 +38,7 @@ class StudyAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
-    return AppBar(
-      backgroundColor: Theme.of(context).primaryColor,
-      elevation: 0,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(bottom: Radius.circular(24)),
-      ),
-      toolbarHeight: 72,
-      leadingWidth: 72,
+    return QuizdyAppBar(
       leading: Padding(
         padding: const EdgeInsets.only(left: 24),
         child: Center(


### PR DESCRIPTION
## Summary
- extract a reusable QuizdyAppBar for the shared purple rounded app bar shell
- migrate existing screens to use the shared app bar while preserving screen-specific behavior
- keep existing navigation and interaction logic for each screen

## Updated screens
- Privacy policy screen
- Quiz loaded screen
- Study app bar
- Study editor component screen
- Study editor section/page manager
- Study editor paragraph property panel

## Validation
- flutter analyze
- flutter test