### PR TITLE
chore: update file_picker to v11.0.1 and migrate API usage

### DIFF
--- a/lib/data/services/file_service/mobile_desktop_file_service.dart
+++ b/lib/data/services/file_service/mobile_desktop_file_service.dart
@@ -95,7 +95,7 @@ class QuizFileService implements IFileService {
         .split(Platform.pathSeparator)
         .last;
 
-    String? outputFile = await FilePicker.platform.saveFile(
+    String? outputFile = await FilePicker.saveFile(
       dialogTitle: dialogTitle,
       fileName: sanitizedFileName,
       allowedExtensions: ['quiz'],
@@ -143,7 +143,7 @@ class QuizFileService implements IFileService {
   /// - Returns: A `QuizFile` object if a valid file is selected, or `null` if no file is selected.
   @override
   Future<QuizFile?> pickFileContent() async {
-    FilePickerResult? result = await FilePicker.platform.pickFiles(
+    FilePickerResult? result = await FilePicker.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['quiz'],
       allowMultiple: false,

--- a/lib/data/services/file_service/web_file_service.dart
+++ b/lib/data/services/file_service/web_file_service.dart
@@ -88,7 +88,7 @@ class QuizFileService implements IFileService {
     final bytes = utf8.encode(jsonString);
 
     // Open a save dialog for the user to select a file path
-    final pathSaved = await FilePicker.platform.saveFile(
+    final pathSaved = await FilePicker.saveFile(
       dialogTitle: dialogTitle,
       fileName: fileName,
       initialDirectory: quizFile.filePath,
@@ -122,7 +122,7 @@ class QuizFileService implements IFileService {
   @override
   Future<QuizFile?> pickFileContent() async {
     // Open the file picker dialog
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['quiz'],
     );

--- a/lib/data/services/pdf_export_service.dart
+++ b/lib/data/services/pdf_export_service.dart
@@ -47,7 +47,7 @@ class StudyPdfExportService {
       latexImages: latexImages,
     );
 
-    final result = await FilePicker.platform.saveFile(
+    final result = await FilePicker.saveFile(
       dialogTitle: dialogTitle,
       fileName: fileName,
       bytes: pdfBytes,

--- a/lib/data/services/pdf_export_service_io.dart
+++ b/lib/data/services/pdf_export_service_io.dart
@@ -50,7 +50,7 @@ class StudyPdfExportService {
       latexImages: latexImages,
     );
 
-    final result = await FilePicker.platform.saveFile(
+    final result = await FilePicker.saveFile(
       dialogTitle: dialogTitle,
       fileName: fileName,
       bytes: pdfBytes,

--- a/lib/presentation/screens/dialogs/ai_generate_questions_dialog.dart
+++ b/lib/presentation/screens/dialogs/ai_generate_questions_dialog.dart
@@ -236,7 +236,7 @@ class _AiGenerateQuestionsDialogState extends State<AiGenerateQuestionsDialog> {
 
   Future<void> _pickFile() async {
     try {
-      final result = await FilePicker.platform.pickFiles(
+      final result = await FilePicker.pickFiles(
         type: FileType.any,
         withData: true,
       );

--- a/lib/presentation/screens/dialogs/ai_generate_study_dialog.dart
+++ b/lib/presentation/screens/dialogs/ai_generate_study_dialog.dart
@@ -176,7 +176,7 @@ class _AiGenerateStudyDialogState extends State<AiGenerateStudyDialog> {
 
   Future<void> _pickFile() async {
     try {
-      final result = await FilePicker.platform.pickFiles(
+      final result = await FilePicker.pickFiles(
         type: FileType.any,
         withData: true,
       );

--- a/lib/presentation/screens/quiz_loaded_screen.dart
+++ b/lib/presentation/screens/quiz_loaded_screen.dart
@@ -102,7 +102,7 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
 
   Future<void> _handleImportButton() async {
     try {
-      FilePickerResult? result = await FilePicker.platform.pickFiles(
+      FilePickerResult? result = await FilePicker.pickFiles(
         type: FileType.custom,
         allowedExtensions: ['quiz'],
       );

--- a/lib/presentation/screens/study_screen.dart
+++ b/lib/presentation/screens/study_screen.dart
@@ -283,7 +283,7 @@ class _StudyScreenViewState extends State<StudyScreenView> {
 
   Future<void> _handleChunkImport() async {
     try {
-      FilePickerResult? result = await FilePicker.platform.pickFiles(
+      FilePickerResult? result = await FilePicker.pickFiles(
         type: FileType.custom,
         allowedExtensions: ['quiz'],
       );
@@ -392,7 +392,7 @@ class _StudyScreenViewState extends State<StudyScreenView> {
       return;
     }
 
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       type: FileType.any,
       withData: true,
     );

--- a/lib/presentation/screens/widgets/add_edit_question/question_image_section.dart
+++ b/lib/presentation/screens/widgets/add_edit_question/question_image_section.dart
@@ -270,7 +270,7 @@ class _QuestionImageSectionState extends State<QuestionImageSection> {
   /// Pick an image file and convert to base64
   Future<void> _pickImage(BuildContext context) async {
     try {
-      FilePickerResult? result = await FilePicker.platform.pickFiles(
+      FilePickerResult? result = await FilePicker.pickFiles(
         type: FileType.image,
         allowMultiple: false,
         withData: true,

--- a/lib/presentation/widgets/ai_file_picker_section.dart
+++ b/lib/presentation/widgets/ai_file_picker_section.dart
@@ -32,7 +32,7 @@ class AiFilePickerSection extends StatelessWidget {
 
   Future<void> _pickFile(BuildContext context) async {
     try {
-      final result = await FilePicker.platform.pickFiles(
+      final result = await FilePicker.pickFiles(
         type: FileType.any,
         withData: true,
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   barcode:
     dependency: transitive
     description:
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: "4df8babf73058181227e18b08e6ea3520cf5fc5d796888d33b7cb0f33f984b7c"
+      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
       url: "https://pub.dev"
     source: hosted
-    version: "12.3.0"
+    version: "12.4.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -268,11 +268,12 @@ packages:
   file_picker:
     dependency: "direct main"
     description:
-      name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.3.10"
+      path: "."
+      ref: "bugfix/resolves-agp9-issues-on-v11.0.0"
+      resolved-ref: "47b0c7acd6a86389f5b793284bfa5543de62f3d7"
+      url: "https://github.com/miguelpruivo/flutter_file_picker.git"
+    source: git
+    version: "11.0.1"
   fixnum:
     dependency: transitive
     description:
@@ -327,10 +328,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.33"
+    version: "2.0.34"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -377,10 +378,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "7974313e217a7771557add6ff2238acb63f635317c35fa590d348fb238f00896"
+      sha256: "48fb2f42ad057476fa4b733cb95e9f9ea7b0b010bb349ea491dca7dbdb18ffc4"
       url: "https://pub.dev"
     source: hosted
-    version: "17.1.0"
+    version: "17.2.0"
   google_fonts:
     dependency: "direct main"
     description:
@@ -393,10 +394,10 @@ packages:
     dependency: "direct main"
     description:
       name: gpt_markdown
-      sha256: "9b88dfaffea644070b648c204ca4a55745a49f4ad0b58ed0ab70913ad593c7a1"
+      sha256: "5c565a438e569b3b546023d0d4eccccf87e260a3289a17c4e241c41d5e7545df"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   hooks:
     dependency: transitive
     description:
@@ -561,10 +562,10 @@ packages:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: "92b2ca62c8bd2b8d2f267cdfccf9bfbdb7322f778f8f91b3ce5b5cda23a3899f"
+      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.5"
+    version: "0.17.6"
   nested:
     dependency: transitive
     description:
@@ -601,10 +602,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -649,10 +650,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.22"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -777,10 +778,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "8374d6200ab33ac99031a852eba4c8eb2170c4bf20778b3e2c9eccb45384fb41"
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.21"
+    version: "2.4.23"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -801,10 +802,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   shared_preferences_web:
     dependency: transitive
     description:
@@ -974,10 +975,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.28"
+    version: "6.3.29"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1038,10 +1039,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "7076216a10d5c390315fbe536a30f1254c341e7543e6c4c8a815e591307772b1"
+      sha256: "81da85e9ca8885ade47f9685b953cb098970d11be4821ac765580a6607ea4373"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.20"
+    version: "1.1.21"
   vector_graphics_codec:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,10 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.9
   desktop_drop: ^0.7.0
-  file_picker: ^10.3.10
+  file_picker:
+    git:
+      url: https://github.com/miguelpruivo/flutter_file_picker.git
+      ref: bugfix/resolves-agp9-issues-on-v11.0.0
   flutter_bloc: ^9.1.1
   flutter_svg: ^2.2.4
   get_it: ^9.2.1


### PR DESCRIPTION
## Summary
- Updated `file_picker` dependency to version `11.0.1` (pointing to a specific bugfix branch on GitHub).
- Migrated all callers from `FilePicker.platform.pickFiles` to the new `FilePicker.pickFiles` API.
- Migrated all callers from `FilePicker.platform.saveFile` to the new `FilePicker.saveFile` API.
- Updated `pubspec.lock` with transitive dependency updates.