### PR TITLE
fix: prevent study mode null crash after AI generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.0]
 
 - ui: The app now looks correct regardless of the font size set in your device's accessibility settings — text no longer overflows or breaks layouts when a larger system font is configured.
+- fix: Prevented a crash when opening Study Mode from Quiz Preview after generating questions with AI by handling missing study chunks safely.
 
 ## [1.11.0] - 2026-04-01
 

--- a/lib/presentation/screens/quiz_loaded_screen.dart
+++ b/lib/presentation/screens/quiz_loaded_screen.dart
@@ -624,12 +624,12 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
                                 AppRoutes.studyScreen,
                                 extra: {
                                   'initialChunks':
-                                      widget.quizFile.study!.content.cache,
+                                      cachedQuizFile.study?.content.cache ?? [],
                                   'documentTitle':
-                                      widget.quizFile.metadata.title,
+                                      cachedQuizFile.metadata.title,
                                   'documentSummary':
-                                      widget.quizFile.metadata.description,
-                                  'quizFile': widget.quizFile,
+                                      cachedQuizFile.metadata.description,
+                                  'quizFile': cachedQuizFile,
                                   'hideStartQuizButton': true,
                                 },
                               );


### PR DESCRIPTION
## Summary
- avoid null-check crash when opening Study Mode from Quiz Loaded screen
- use cached quiz file data for study navigation extras
- pass safe fallback chunks when study content is null

## Testing
- flutter analyze
- manual review