### PR TITLE
Fix: Navigation and UI refactor: Mode switching flow between Study and Quiz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ui: The app now looks correct regardless of the font size set in your device's accessibility settings — text no longer overflows or breaks layouts when a larger system font is configured.
 - fix: Prevented a crash when opening Study Mode from Quiz Preview after generating questions with AI by handling missing study chunks safely.
 - fix: Fixed file picker behaviour on web loading files.
+- fix: Navigation and UI refactor: Mode switching flow between Study and Quiz
 
 ## [1.11.0] - 2026-04-01
 

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -68,7 +68,7 @@ class _HomeScreenState extends State<HomeScreen> {
     if (mode == QuizMode.study) {
       _navigateToStudy(context, quizFile);
     } else {
-      context.go(AppRoutes.fileLoadedScreen);
+      context.push(AppRoutes.fileLoadedScreen);
     }
   }
 

--- a/lib/presentation/screens/quiz_loaded_screen.dart
+++ b/lib/presentation/screens/quiz_loaded_screen.dart
@@ -528,468 +528,461 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
               context.presentSnackBar(state.getDescription(context));
             }
           },
-          child: Builder(
-            builder: (context) {
-              return Scaffold(
-                appBar: QuizdyAppBar(
-                  onLeadingPressed: () async {
-                    final shouldExit = await _confirmExit();
-                    if (shouldExit && context.mounted) {
-                      if (context.canPop()) {
-                        context.pop();
-                      } else {
-                        context.go(AppRoutes.home);
+          child: Scaffold(
+            appBar: QuizdyAppBar(
+              leading: Center(
+                child: Container(
+                  width: 40,
+                  height: 40,
+                  margin: const EdgeInsets.only(left: 8),
+                  decoration: BoxDecoration(
+                    color: context.quizLoadedTheme.appBarIconBackgroundColor,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: IconButton(
+                    padding: EdgeInsets.zero,
+                    icon: Icon(
+                      Icons.close,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                      size: 20,
+                    ),
+                    onPressed: () async {
+                      final shouldExit = await _confirmExit();
+                      if (shouldExit && context.mounted) {
+                        if (context.canPop()) {
+                          context.pop();
+                        } else {
+                          context.go(AppRoutes.home);
+                        }
                       }
-                    }
-                  },
-                  title: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Flexible(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            MouseRegion(
-                              cursor: SystemMouseCursors.click,
-                              child: GestureDetector(
-                                onTap: () async {
-                                  final result =
-                                      await showDialog<Map<String, String>>(
-                                        context: context,
-                                        builder: (context) =>
-                                            QuizMetadataDialog(
-                                              isEditing: true,
-                                              initialName:
-                                                  cachedQuizFile.metadata.title,
-                                              initialDescription: cachedQuizFile
-                                                  .metadata
-                                                  .description,
-                                              initialAuthor: cachedQuizFile
-                                                  .metadata
-                                                  .author,
-                                            ),
-                                      );
+                    },
+                    tooltip: AppLocalizations.of(context)!.close,
+                  ),
+                ),
+              ),
 
-                                  if (result != null && mounted) {
-                                    setState(() {
-                                      cachedQuizFile = cachedQuizFile.copyWith(
-                                        metadata: cachedQuizFile.metadata
-                                            .copyWith(
-                                              title: result['name'],
-                                              description:
-                                                  result['description'],
-                                              author: result['author'],
-                                            ),
-                                      );
-                                    });
-                                    _syncQuizFileToBloc();
-                                  }
-                                },
-                                child: Text(
-                                  AppLocalizations.of(
-                                    context,
-                                  )!.quizPreviewTitle,
-                                  style: TextStyle(
+              title: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        MouseRegion(
+                          cursor: SystemMouseCursors.click,
+                          child: GestureDetector(
+                            onTap: () async {
+                              final result =
+                                  await showDialog<Map<String, String>>(
+                                    context: context,
+                                    builder: (context) => QuizMetadataDialog(
+                                      isEditing: true,
+                                      initialName:
+                                          cachedQuizFile.metadata.title,
+                                      initialDescription:
+                                          cachedQuizFile.metadata.description,
+                                      initialAuthor:
+                                          cachedQuizFile.metadata.author,
+                                    ),
+                                  );
+
+                              if (result != null && mounted) {
+                                setState(() {
+                                  cachedQuizFile = cachedQuizFile.copyWith(
+                                    metadata: cachedQuizFile.metadata.copyWith(
+                                      title: result['name'],
+                                      description: result['description'],
+                                      author: result['author'],
+                                    ),
+                                  );
+                                });
+                                _syncQuizFileToBloc();
+                              }
+                            },
+                            child: Text(
+                              AppLocalizations.of(context)!.quizPreviewTitle,
+                              style: TextStyle(
+                                color: Theme.of(context).colorScheme.onPrimary,
+                                fontSize: 20,
+                                fontWeight: FontWeight.w700,
+                                fontFamily: 'Plus Jakarta Sans',
+                              ),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              actions: [
+                // Study Mode Button
+                Tooltip(
+                  message: AppLocalizations.of(context)!.studyModeLabel,
+                  child: Container(
+                    margin: const EdgeInsets.only(right: 8),
+                    constraints: const BoxConstraints(minWidth: 40),
+                    child: Material(
+                      color: context.quizLoadedTheme.appBarIconBackgroundColor,
+                      borderRadius: BorderRadius.circular(20),
+                      child: InkWell(
+                        borderRadius: BorderRadius.circular(20),
+                        onTap: () {
+                          context.pushReplacement(
+                            AppRoutes.studyScreen,
+                            extra: {
+                              'initialChunks':
+                                  cachedQuizFile.study?.content.cache ?? [],
+                              'documentTitle': cachedQuizFile.metadata.title,
+                              'documentSummary':
+                                  cachedQuizFile.metadata.description,
+                              'quizFile': cachedQuizFile,
+                              'hideStartQuizButton': true,
+                            },
+                          );
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 10,
+                          ),
+                          child: Builder(
+                            builder: (context) {
+                              final showText =
+                                  MediaQuery.of(context).size.width > 500;
+                              return Row(
+                                mainAxisSize: MainAxisSize.min,
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(
+                                    LucideIcons.bookOpen,
                                     color: Theme.of(
                                       context,
                                     ).colorScheme.onPrimary,
-                                    fontSize: 20,
-                                    fontWeight: FontWeight.w700,
-                                    fontFamily: 'Plus Jakarta Sans',
+                                    size: 18,
                                   ),
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                  actions: [
-                    // Study Mode Button
-                    Tooltip(
-                      message: AppLocalizations.of(context)!.studyModeLabel,
-                      child: Container(
-                        margin: const EdgeInsets.only(right: 8),
-                        constraints: const BoxConstraints(minWidth: 40),
-                        child: Material(
-                          color:
-                              context.quizLoadedTheme.appBarIconBackgroundColor,
-                          borderRadius: BorderRadius.circular(20),
-                          child: InkWell(
-                            borderRadius: BorderRadius.circular(20),
-                            onTap: () {
-                              context.push(
-                                AppRoutes.studyScreen,
-                                extra: {
-                                  'initialChunks':
-                                      cachedQuizFile.study?.content.cache ?? [],
-                                  'documentTitle':
-                                      cachedQuizFile.metadata.title,
-                                  'documentSummary':
-                                      cachedQuizFile.metadata.description,
-                                  'quizFile': cachedQuizFile,
-                                  'hideStartQuizButton': true,
-                                },
-                              );
-                            },
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 10,
-                              ),
-                              child: Builder(
-                                builder: (context) {
-                                  final showText =
-                                      MediaQuery.of(context).size.width > 500;
-                                  return Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Icon(
-                                        LucideIcons.bookOpen,
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.onPrimary,
-                                        size: 18,
-                                      ),
-                                      if (showText) ...[
-                                        const SizedBox(width: 6),
-                                        Text(
-                                          AppLocalizations.of(
-                                            context,
-                                          )!.studyModeLabel,
-                                          style: TextStyle(
-                                            color: Theme.of(
-                                              context,
-                                            ).colorScheme.onPrimary,
-                                            fontSize: 13,
-                                            fontWeight: FontWeight.w600,
-                                          ),
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                      ],
-                                    ],
-                                  );
-                                },
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    // Settings Button
-                    Container(
-                      width: 40,
-                      height: 40,
-                      margin: const EdgeInsets.only(right: 8),
-                      decoration: BoxDecoration(
-                        color:
-                            context.quizLoadedTheme.appBarIconBackgroundColor,
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: IconButton(
-                        padding: EdgeInsets.zero,
-                        onPressed: () => _showSettingsDialog(context),
-                        icon: Icon(
-                          LucideIcons.settings,
-                          color: Theme.of(context).colorScheme.onPrimary,
-                          size: 20,
-                        ),
-                        tooltip: AppLocalizations.of(context)!.settingsTitle,
-                      ),
-                    ),
-                    Container(
-                      margin: const EdgeInsets.only(right: 24),
-                      constraints: const BoxConstraints(minWidth: 40),
-                      child: Tooltip(
-                        message: _isSelectionMode
-                            ? AppLocalizations.of(context)!.done
-                            : AppLocalizations.of(context)!.select,
-                        child: Material(
-                          color: context
-                              .quizLoadedTheme
-                              .selectionInactiveBackgroundColor,
-                          borderRadius: BorderRadius.circular(12),
-                          child: InkWell(
-                            borderRadius: BorderRadius.circular(12),
-                            onTap: () {
-                              _toggleSelectionMode();
-                            },
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 10,
-                              ),
-                              child: Builder(
-                                builder: (context) {
-                                  final showText =
-                                      MediaQuery.of(context).size.width > 500;
-
-                                  return Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Icon(
-                                        _isSelectionMode
-                                            ? LucideIcons.checkSquare
-                                            : LucideIcons.mousePointer2,
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.onPrimary,
-                                        size: 18,
-                                      ),
-                                      if (showText) ...[
-                                        const SizedBox(width: 8),
-                                        Flexible(
-                                          child: Text(
-                                            _isSelectionMode
-                                                ? AppLocalizations.of(
-                                                    context,
-                                                  )!.done
-                                                : AppLocalizations.of(
-                                                    context,
-                                                  )!.select,
-                                            style: TextStyle(
-                                              color: Theme.of(
-                                                context,
-                                              ).colorScheme.onPrimary,
-                                              fontSize: 13,
-                                              fontWeight: FontWeight.w600,
-                                            ),
-                                            overflow: TextOverflow.ellipsis,
-                                          ),
-                                        ),
-                                      ],
-                                    ],
-                                  );
-                                },
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                body: DropTarget(
-                  onDragDone: (details) {
-                    if (ModalRoute.of(context)?.isCurrent != true) {
-                      return;
-                    }
-                    setState(() => _isDragging = false);
-                    if (ServiceLocator.getIt<DialogDropGuard>().isActive) {
-                      return;
-                    }
-                    if (details.files.isNotEmpty) {
-                      final firstFile = details.files.first;
-                      if (firstFile.path.isNotEmpty) {
-                        if (!firstFile.name.toLowerCase().endsWith('.quiz')) {
-                          if (mounted) {
-                            context.presentSnackBar(
-                              AppLocalizations.of(context)!.errorInvalidFile,
-                            );
-                          }
-                          return;
-                        }
-                        _handleFileImport(firstFile.path);
-                      }
-                    }
-                  },
-                  onDragEntered: (_) {
-                    if (!ServiceLocator.getIt<DialogDropGuard>().isActive) {
-                      setState(() => _isDragging = true);
-                    }
-                  },
-                  onDragExited: (_) => setState(() => _isDragging = false),
-                  child: Stack(
-                    children: [
-                      if (cachedQuizFile.questions.isEmpty)
-                        QuizdyEmptyState(
-                          message: AppLocalizations.of(
-                            context,
-                          )!.quizLoadedNoQuestionsAvailable,
-                          icon: LucideIcons.fileQuestion,
-                        )
-                      else
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                          child: QuestionListWidget(
-                            quizFile: cachedQuizFile,
-                            onFileChange: () {
-                              setState(() {});
-                              _syncQuizFileToBloc();
-                            },
-                            isSelectionMode: _isSelectionMode,
-                            selectedQuestions: _selectedQuestions,
-                            onToggleSelection: _toggleQuestionSelection,
-                            onSelectionChanged: (newSelection) {
-                              setState(() {
-                                _selectedQuestions.clear();
-                                _selectedQuestions.addAll(newSelection);
-                              });
-                            },
-                          ),
-                        ),
-                      if (_isDragging)
-                        Positioned.fill(
-                          child: Container(
-                            color: context.quizLoadedTheme.dragOverlayColor,
-                            child: Center(
-                              child: Container(
-                                padding: const EdgeInsets.all(32),
-                                decoration: BoxDecoration(
-                                  color: Theme.of(context).cardColor,
-                                  borderRadius: BorderRadius.circular(24),
-                                  border: Border.all(
-                                    color: context
-                                        .quizLoadedTheme
-                                        .dragOverlayBorderColor,
-                                    width: 3,
-                                  ),
-                                  boxShadow: [
-                                    BoxShadow(
-                                      color: context
-                                          .quizLoadedTheme
-                                          .dragOverlayShadowColor,
-                                      blurRadius: 20,
-                                      offset: const Offset(0, 10),
-                                    ),
-                                  ],
-                                ),
-                                child: Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    Icon(
-                                      LucideIcons.upload,
-                                      size: 48,
-                                      color: Theme.of(context).primaryColor,
-                                    ),
-                                    const SizedBox(height: 16),
+                                  if (showText) ...[
+                                    const SizedBox(width: 6),
                                     Text(
                                       AppLocalizations.of(
                                         context,
-                                      )!.dropFileHere,
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .headlineMedium
-                                          ?.copyWith(
-                                            color: Theme.of(
-                                              context,
-                                            ).primaryColor,
-                                          ),
+                                      )!.studyModeLabel,
+                                      style: TextStyle(
+                                        color: Theme.of(
+                                          context,
+                                        ).colorScheme.onPrimary,
+                                        fontSize: 13,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                      overflow: TextOverflow.ellipsis,
                                     ),
                                   ],
-                                ),
+                                ],
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                // Settings Button
+                Container(
+                  width: 40,
+                  height: 40,
+                  margin: const EdgeInsets.only(right: 8),
+                  decoration: BoxDecoration(
+                    color: context.quizLoadedTheme.appBarIconBackgroundColor,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: IconButton(
+                    padding: EdgeInsets.zero,
+                    onPressed: () => _showSettingsDialog(context),
+                    icon: Icon(
+                      LucideIcons.settings,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                      size: 20,
+                    ),
+                    tooltip: AppLocalizations.of(context)!.settingsTitle,
+                  ),
+                ),
+                Container(
+                  margin: const EdgeInsets.only(right: 24),
+                  constraints: const BoxConstraints(minWidth: 40),
+                  child: Tooltip(
+                    message: _isSelectionMode
+                        ? AppLocalizations.of(context)!.done
+                        : AppLocalizations.of(context)!.select,
+                    child: Material(
+                      color: context
+                          .quizLoadedTheme
+                          .selectionInactiveBackgroundColor,
+                      borderRadius: BorderRadius.circular(12),
+                      child: InkWell(
+                        borderRadius: BorderRadius.circular(12),
+                        onTap: () {
+                          _toggleSelectionMode();
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 10,
+                          ),
+                          child: Builder(
+                            builder: (context) {
+                              final showText =
+                                  MediaQuery.of(context).size.width > 500;
+
+                              return Row(
+                                mainAxisSize: MainAxisSize.min,
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(
+                                    _isSelectionMode
+                                        ? LucideIcons.checkSquare
+                                        : LucideIcons.mousePointer2,
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onPrimary,
+                                    size: 18,
+                                  ),
+                                  if (showText) ...[
+                                    const SizedBox(width: 8),
+                                    Flexible(
+                                      child: Text(
+                                        _isSelectionMode
+                                            ? AppLocalizations.of(context)!.done
+                                            : AppLocalizations.of(
+                                                context,
+                                              )!.select,
+                                        style: TextStyle(
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.onPrimary,
+                                          fontSize: 13,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ),
+                                  ],
+                                ],
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            body: DropTarget(
+              onDragDone: (details) {
+                if (ModalRoute.of(context)?.isCurrent != true) {
+                  return;
+                }
+                setState(() => _isDragging = false);
+                if (ServiceLocator.getIt<DialogDropGuard>().isActive) {
+                  return;
+                }
+                if (details.files.isNotEmpty) {
+                  final firstFile = details.files.first;
+                  if (firstFile.path.isNotEmpty) {
+                    if (!firstFile.name.toLowerCase().endsWith('.quiz')) {
+                      if (mounted) {
+                        context.presentSnackBar(
+                          AppLocalizations.of(context)!.errorInvalidFile,
+                        );
+                      }
+                      return;
+                    }
+                    _handleFileImport(firstFile.path);
+                  }
+                }
+              },
+              onDragEntered: (_) {
+                if (!ServiceLocator.getIt<DialogDropGuard>().isActive) {
+                  setState(() => _isDragging = true);
+                }
+              },
+              onDragExited: (_) => setState(() => _isDragging = false),
+              child: Stack(
+                children: [
+                  if (cachedQuizFile.questions.isEmpty)
+                    QuizdyEmptyState(
+                      message: AppLocalizations.of(
+                        context,
+                      )!.quizLoadedNoQuestionsAvailable,
+                      icon: LucideIcons.fileQuestion,
+                    )
+                  else
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                      child: QuestionListWidget(
+                        quizFile: cachedQuizFile,
+                        onFileChange: () {
+                          setState(() {});
+                          _syncQuizFileToBloc();
+                        },
+                        isSelectionMode: _isSelectionMode,
+                        selectedQuestions: _selectedQuestions,
+                        onToggleSelection: _toggleQuestionSelection,
+                        onSelectionChanged: (newSelection) {
+                          setState(() {
+                            _selectedQuestions.clear();
+                            _selectedQuestions.addAll(newSelection);
+                          });
+                        },
+                      ),
+                    ),
+                  if (_isDragging)
+                    Positioned.fill(
+                      child: Container(
+                        color: context.quizLoadedTheme.dragOverlayColor,
+                        child: Center(
+                          child: Container(
+                            padding: const EdgeInsets.all(32),
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).cardColor,
+                              borderRadius: BorderRadius.circular(24),
+                              border: Border.all(
+                                color: context
+                                    .quizLoadedTheme
+                                    .dragOverlayBorderColor,
+                                width: 3,
                               ),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: context
+                                      .quizLoadedTheme
+                                      .dragOverlayShadowColor,
+                                  blurRadius: 20,
+                                  offset: const Offset(0, 10),
+                                ),
+                              ],
+                            ),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(
+                                  LucideIcons.upload,
+                                  size: 48,
+                                  color: Theme.of(context).primaryColor,
+                                ),
+                                const SizedBox(height: 16),
+                                Text(
+                                  AppLocalizations.of(context)!.dropFileHere,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .headlineMedium
+                                      ?.copyWith(
+                                        color: Theme.of(context).primaryColor,
+                                      ),
+                                ),
+                              ],
                             ),
                           ),
                         ),
-                    ],
-                  ),
-                ),
-
-                bottomNavigationBar: QuizLoadedBottomBar(
-                  onAddQuestion: () async {
-                    final createdQuestion = await showDialog<Question>(
-                      context: context,
-                      barrierDismissible: false,
-                      builder: (context) =>
-                          AddEditQuestionDialog(quizFile: cachedQuizFile),
-                    );
-                    if (createdQuestion != null) {
-                      setState(() {
-                        cachedQuizFile.questions.add(createdQuestion);
-                      });
-                    }
-                  },
-                  onGenerateAI: () async {
-                    await _generateQuestionsWithAI();
-                  },
-                  onImport: _handleImportButton,
-                  onSave: _handleSave,
-                  onDelete: _handleDeleteQuestions,
-                  onDeleteDuplicates: _handleDeleteDuplicates,
-                  hasDuplicates: _getDuplicatedIndices().isNotEmpty,
-                  selectedQuestionCount: _selectedQuestions.length,
-                  showSaveButton: widget.checkFileChangesUseCase.execute(
-                    cachedQuizFile,
-                  ),
-                  hasQuestions: cachedQuizFile.questions.isNotEmpty,
-                  isPlayEnabled: cachedQuizFile.questions.any(
-                    (q) => q.isEnabled,
-                  ),
-                  onPlay: () async {
-                    // Filter enabled questions first
-                    final enabledQuestions = cachedQuizFile.questions
-                        .where((question) => question.isEnabled)
-                        .toList();
-
-                    if (enabledQuestions.isEmpty) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text(
-                            AppLocalizations.of(
-                              context,
-                            )!.noEnabledQuestionsError,
-                          ),
-                          backgroundColor: Theme.of(
-                            context,
-                          ).extension<CustomColors>()!.warning,
-                        ),
-                      );
-                      return;
-                    }
-
-                    // Count selected questions that are also enabled
-                    final selectedEnabledCount = _selectedQuestions
-                        .where(
-                          (index) =>
-                              index < cachedQuizFile.questions.length &&
-                              cachedQuizFile.questions[index].isEnabled,
-                        )
-                        .length;
-
-                    final quizConfig = await showDialog<QuizConfig>(
-                      context: context,
-                      builder: (context) => QuestionCountSelectionDialog(
-                        totalQuestions: enabledQuestions.length,
-                        selectedQuestionCount: _isSelectionMode
-                            ? selectedEnabledCount
-                            : 0,
                       ),
-                    );
+                    ),
+                ],
+              ),
+            ),
 
-                    if (quizConfig != null && context.mounted) {
-                      QuizFile quizFileToUse = cachedQuizFile;
+            bottomNavigationBar: QuizLoadedBottomBar(
+              onAddQuestion: () async {
+                final createdQuestion = await showDialog<Question>(
+                  context: context,
+                  barrierDismissible: false,
+                  builder: (context) =>
+                      AddEditQuestionDialog(quizFile: cachedQuizFile),
+                );
+                if (createdQuestion != null) {
+                  setState(() {
+                    cachedQuizFile.questions.add(createdQuestion);
+                  });
+                }
+              },
+              onGenerateAI: () async {
+                await _generateQuestionsWithAI();
+              },
+              onImport: _handleImportButton,
+              onSave: _handleSave,
+              onDelete: _handleDeleteQuestions,
+              onDeleteDuplicates: _handleDeleteDuplicates,
+              hasDuplicates: _getDuplicatedIndices().isNotEmpty,
+              selectedQuestionCount: _selectedQuestions.length,
+              showSaveButton: widget.checkFileChangesUseCase.execute(
+                cachedQuizFile,
+              ),
+              hasQuestions: cachedQuizFile.questions.isNotEmpty,
+              isPlayEnabled: cachedQuizFile.questions.any((q) => q.isEnabled),
+              onPlay: () async {
+                // Filter enabled questions first
+                final enabledQuestions = cachedQuizFile.questions
+                    .where((question) => question.isEnabled)
+                    .toList();
 
-                      if (quizConfig.useSelectedOnly) {
-                        // Filter to only the selected + enabled questions
-                        final selectedQuestions = <Question>[];
-                        for (final index in _selectedQuestions) {
-                          if (index < cachedQuizFile.questions.length &&
-                              cachedQuizFile.questions[index].isEnabled) {
-                            selectedQuestions.add(
-                              cachedQuizFile.questions[index],
-                            );
-                          }
-                        }
-                        quizFileToUse = cachedQuizFile.copyWith(
-                          questions: selectedQuestions,
-                        );
+                if (enabledQuestions.isEmpty) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                        AppLocalizations.of(context)!.noEnabledQuestionsError,
+                      ),
+                      backgroundColor: Theme.of(
+                        context,
+                      ).extension<CustomColors>()!.warning,
+                    ),
+                  );
+                  return;
+                }
+
+                // Count selected questions that are also enabled
+                final selectedEnabledCount = _selectedQuestions
+                    .where(
+                      (index) =>
+                          index < cachedQuizFile.questions.length &&
+                          cachedQuizFile.questions[index].isEnabled,
+                    )
+                    .length;
+
+                final quizConfig = await showDialog<QuizConfig>(
+                  context: context,
+                  builder: (context) => QuestionCountSelectionDialog(
+                    totalQuestions: enabledQuestions.length,
+                    selectedQuestionCount: _isSelectionMode
+                        ? selectedEnabledCount
+                        : 0,
+                  ),
+                );
+
+                if (quizConfig != null && context.mounted) {
+                  QuizFile quizFileToUse = cachedQuizFile;
+
+                  if (quizConfig.useSelectedOnly) {
+                    // Filter to only the selected + enabled questions
+                    final selectedQuestions = <Question>[];
+                    for (final index in _selectedQuestions) {
+                      if (index < cachedQuizFile.questions.length &&
+                          cachedQuizFile.questions[index].isEnabled) {
+                        selectedQuestions.add(cachedQuizFile.questions[index]);
                       }
-
-                      ServiceLocator.registerQuizFile(quizFileToUse);
-                      ServiceLocator.registerQuizConfig(quizConfig);
-                      context.push(AppRoutes.quizFileExecutionScreen);
                     }
-                  },
-                ),
-              );
-            },
+                    quizFileToUse = cachedQuizFile.copyWith(
+                      questions: selectedQuestions,
+                    );
+                  }
+
+                  ServiceLocator.registerQuizFile(quizFileToUse);
+                  ServiceLocator.registerQuizConfig(quizConfig);
+                  context.push(AppRoutes.quizFileExecutionScreen);
+                }
+              },
+            ),
           ),
         ),
       ),

--- a/lib/presentation/screens/widgets/study/study_app_bar.dart
+++ b/lib/presentation/screens/widgets/study/study_app_bar.dart
@@ -44,52 +44,50 @@ class StudyAppBar extends StatelessWidget implements PreferredSizeWidget {
     final localizations = AppLocalizations.of(context)!;
 
     return QuizdyAppBar(
-      leading: Padding(
-        padding: const EdgeInsets.only(left: 24),
-        child: Center(
-          child: Container(
-            width: 40,
-            height: 40,
-            decoration: BoxDecoration(
-              color: context.quizLoadedTheme.appBarIconBackgroundColor,
-              borderRadius: BorderRadius.circular(20),
-            ),
-            child: BlocBuilder<StudyExecutionBloc, StudyExecutionState>(
-              builder: (context, state) {
-                return AbsorbPointer(
-                  absorbing: state.isLoading,
-                  child: IconButton(
-                    padding: EdgeInsets.zero,
-                    icon: Icon(
-                      LucideIcons.arrowLeft,
-                      color: Theme.of(context).colorScheme.onPrimary,
-                      size: 20,
-                    ),
-                    tooltip: localizations.backSemanticLabel,
-                    onPressed: () async {
-                      if (state.isSelectionMode) {
-                        context.read<StudyExecutionBloc>().add(
-                          const ClearSelectionRequested(),
-                        );
-                        return;
-                      }
-                      if (!state.isIndexMode) {
-                        context.read<StudyExecutionBloc>().add(
-                          const ReturnToIndexRequested(),
-                        );
-                        return;
-                      }
-                      final shouldExit = await onConfirmExit();
-                      if (shouldExit && context.mounted) {
-                        context.read<FileBloc>().add(QuizFileReset());
-                        context.pop();
-                      }
-                    },
+      leading: Center(
+        child: BlocBuilder<StudyExecutionBloc, StudyExecutionState>(
+          builder: (context, state) {
+            return AbsorbPointer(
+              absorbing: state.isLoading,
+              child: Container(
+                width: 40,
+                height: 40,
+                margin: const EdgeInsets.only(left: 8),
+                decoration: BoxDecoration(
+                  color: context.quizLoadedTheme.appBarIconBackgroundColor,
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: IconButton(
+                  padding: EdgeInsets.zero,
+                  icon: Icon(
+                    Icons.close,
+                    color: Theme.of(context).colorScheme.onPrimary,
+                    size: 20,
                   ),
-                );
-              },
-            ),
-          ),
+                  onPressed: () async {
+                    if (state.isSelectionMode) {
+                      context.read<StudyExecutionBloc>().add(
+                        const ClearSelectionRequested(),
+                      );
+                      return;
+                    }
+                    if (!state.isIndexMode) {
+                      context.read<StudyExecutionBloc>().add(
+                        const ReturnToIndexRequested(),
+                      );
+                      return;
+                    }
+                    final shouldExit = await onConfirmExit();
+                    if (shouldExit && context.mounted) {
+                      context.read<FileBloc>().add(QuizFileReset());
+                      context.pop();
+                    }
+                  },
+                  tooltip: AppLocalizations.of(context)!.close,
+                ),
+              ),
+            );
+          },
         ),
       ),
       title: Row(

--- a/lib/presentation/screens/widgets/study/study_bottom_navigation.dart
+++ b/lib/presentation/screens/widgets/study/study_bottom_navigation.dart
@@ -118,7 +118,7 @@ class StudyBottomNavigation extends StatelessWidget {
                     },
                     onStartQuiz: () {
                       ServiceLocator.registerQuizFile(currentQuizFile);
-                      context.push(AppRoutes.fileLoadedScreen);
+                      context.pushReplacement(AppRoutes.fileLoadedScreen);
                     },
                     onAddChunk: onAddChunk,
                     onGenerateAI: onGenerateAI,

--- a/lib/presentation/screens/widgets/study/study_index_footer_widget.dart
+++ b/lib/presentation/screens/widgets/study/study_index_footer_widget.dart
@@ -400,9 +400,7 @@ class _StudyIndexFooterWidgetState extends State<StudyIndexFooterWidget> {
                             title: widget.localizations.startQuizFromStudy,
                             icon: LucideIcons.play,
                             expanded: true,
-                            onPressed: widget.isStartQuizEnabled
-                                ? widget.onStartQuiz
-                                : null,
+                            onPressed: widget.onStartQuiz,
                           ),
                         ),
                       ),


### PR DESCRIPTION
## Summary

  Fixes: #359 — Navigation and UI refactor: Mode switching flow between Study
  and Quiz.

  - Lock the Start Quiz button when no study chunks are available or all chunks
    are still being processed, so the quiz cannot be started until content is
    ready.
  - Replace the back arrow in the Quiz execution screen header with an X (Close)
    button that terminates the session and navigates directly to the Home screen,
    bypassing any intermediate screens in the navigation stack.
  - Ensure that tapping X resets the quiz and file bloc state before going home,
    so no stale progress leaks into subsequent sessions.