### PR TITLE
fix: updated Gemini API key regex in order to accept new format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Added `QuizdyLoading` widget and implemened in whole app.
 - feat: Implemented index, cover page, and new look to the extracted pdf.
 - feat: Implemented pdf preview dialog in order to save or share it.
+- fix: updated `Gemini` API key regex in order to accept new format.
 
 ## [1.11.0] - 2026-04-01
 

--- a/lib/core/extensions/string_extension.dart
+++ b/lib/core/extensions/string_extension.dart
@@ -103,7 +103,7 @@ extension StringExtension on String {
   bool get isValidGeminiApiKey {
     if (trim().isEmpty) return false;
     // Gemini keys start with "AIza" and are typically 39 chars
-    final regex = RegExp(r'^AIza[a-zA-Z0-9_-]{31,}$');
+    final regex = RegExp(r'^(AIza[a-zA-Z0-9_-]{31,}|AQ\.[a-zA-Z0-9_-]{31,})$');
     return regex.hasMatch(trim());
   }
 


### PR DESCRIPTION
## Description                                                                                                                                                                                       
                                                                                                                                                                                                       
  Updated the Gemini API key validation regex to support the new key format introduced by Google.                                                                                                      
                                                                                                                                                                                                       
  Previously, the regex only accepted keys starting with `AIza` (legacy format). Google has started issuing keys with a new format beginning with `AQ.`, which were being rejected as invalid.

Fixes: #368 
                                                                                                                                                                                                       
  ## Changes                                                                                                                                                                                           
                                                                                                                                                                                                       
  - **File:** `lib/core/extensions/string_extension.dart`                                                                                                                                            
  - Updated `isValidGeminiApiKey` regex from `^AIza[a-zA-Z0-9_-]{31,}$` to `^(AIza[a-zA-Z0-9_-]{31,}|AQ\.[a-zA-Z0-9_-]{31,})$`                                                                         
                                                                                                                                                                                                       
  ## Root Cause                                                                                                                                                                                        
                                                                                                                                                                                                       
  Google introduced a new Gemini API key format (`AQ.<suffix>`) alongside the existing one (`AIza<suffix>`). The old regex was too strict and rejected valid keys of the new format.