### PR TITLE
Refine Snapcraft workflow by adjusting build command

### DIFF
--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -38,15 +38,15 @@ jobs:
         run: flutter build web --release --base-href /${{ github.event.repository.name }}/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
         with:
           enablement: true
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "./build/web"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/flutter_workflow.yml
+++ b/.github/workflows/flutter_workflow.yml
@@ -14,11 +14,7 @@ jobs:
     name: Run flutter test and analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "zulu"
-          java-version: "12"
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"

--- a/.github/workflows/pencil_review.yml
+++ b/.github/workflows/pencil_review.yml
@@ -14,7 +14,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: remotestate/pencil-actions@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_android.yml
+++ b/.github/workflows/publish_android.yml
@@ -10,7 +10,7 @@ jobs:
     name: Generate Android Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Download Android keystore
         id: android_keystore
         uses: timheuer/base64-to-file@v1

--- a/.github/workflows/publish_appgallery.yml
+++ b/.github/workflows/publish_appgallery.yml
@@ -11,7 +11,7 @@ jobs:
     name: Generate AppGallery Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Download Android keystore
         id: android_keystore

--- a/.github/workflows/publish_microsoft_store.yml
+++ b/.github/workflows/publish_microsoft_store.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/publish_snap.yml
+++ b/.github/workflows/publish_snap.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install core24 snap
         run: sudo snap install core24 --channel=latest/stable
 
+      - name: Setup LXD (for managed builds)
+        uses: canonical/setup-lxd@main
+
       - name: Extract Flutter version
         id: flutter_version
         run: |
@@ -39,7 +42,7 @@ jobs:
           sed -i "s/^version: .*/version: \"$VERSION\"/" snap/snapcraft.yaml
 
       - name: Build snap
-        run: snapcraft pack --debug --destructive-mode
+        run: snapcraft pack --debug --use-lxd
 
       - name: Publish to Snap Store
         run: snapcraft upload quiz-app*.snap --release=stable

--- a/.github/workflows/publish_snap.yml
+++ b/.github/workflows/publish_snap.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-    branches:
-      - '**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish_snap.yml
+++ b/.github/workflows/publish_snap.yml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
-    branches-ignore:
+    branches:
       - '**'
   workflow_dispatch:
 

--- a/.github/workflows/publish_snap.yml
+++ b/.github/workflows/publish_snap.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - 'v*.*.*'
+    branches-ignore:
+      - '**'
   workflow_dispatch:
 
 jobs:
@@ -10,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -26,9 +28,6 @@ jobs:
       - name: Install core24 snap
         run: sudo snap install core24 --channel=latest/stable
 
-      - name: Setup LXD (for managed builds)
-        uses: canonical/setup-lxd@main
-
       - name: Extract Flutter version
         id: flutter_version
         run: |
@@ -40,7 +39,7 @@ jobs:
           sed -i "s/^version: .*/version: \"$VERSION\"/" snap/snapcraft.yaml
 
       - name: Build snap
-        run: snapcraft pack --debug --use-lxd
+        run: snapcraft pack --debug --destructive-mode
 
       - name: Publish to Snap Store
         run: snapcraft upload quiz-app*.snap --release=stable


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to use the latest versions of their actions, improving security and compatibility. Additionally, it expands the trigger conditions for the Snap publishing workflow to include all branches as well as tags.

**GitHub Actions version upgrades:**

* Updated all references to `actions/checkout` to use version `v6` in the following workflows: `deploy_web.yml`, `flutter_workflow.yml`, `pencil_review.yml`, `publish_android.yml`, `publish_appgallery.yml`, `publish_microsoft_store.yml`, and `publish_snap.yml`.
* Updated other GitHub Actions in `deploy_web.yml` to their latest major versions: `actions/configure-pages` to `v6`, `actions/upload-pages-artifact` to `v5`, and `actions/deploy-pages` to `v5`.

**Workflow trigger improvements:**

* Modified `publish_snap.yml` to trigger on pushes to any branch (in addition to tags), ensuring releases can be published from all branches.