### PR TITLE
refactor: refactored and extracted widgets

### DIFF
--- a/lib/presentation/screens/dialogs/count_selection/collapsible_exam_config.dart
+++ b/lib/presentation/screens/dialogs/count_selection/collapsible_exam_config.dart
@@ -1,0 +1,125 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+
+class CollapsibleExamConfig extends StatefulWidget {
+  final bool isDark;
+  final Widget child;
+
+  const CollapsibleExamConfig({
+    super.key,
+    required this.isDark,
+    required this.child,
+  });
+
+  @override
+  State<CollapsibleExamConfig> createState() => _CollapsibleExamConfigState();
+}
+
+class _CollapsibleExamConfigState extends State<CollapsibleExamConfig> {
+  bool _isExpanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderColor = widget.isDark
+        ? const Color(0xFF3F3F46)
+        : const Color(0xFFE4E4E7);
+    final headerBgColor = widget.isDark
+        ? const Color(0xFF3F3F46)
+        : const Color(0xFFF4F4F5);
+    final bodyBgColor = widget.isDark
+        ? const Color(0xFF1E1E22)
+        : const Color(0xFFFAFAFA);
+    final iconColor = widget.isDark
+        ? const Color(0xFFA1A1AA)
+        : const Color(0xFF71717A);
+    final titleColor = widget.isDark ? Colors.white : const Color(0xFF18181B);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        GestureDetector(
+          onTap: () {
+            setState(() {
+              _isExpanded = !_isExpanded;
+            });
+          },
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+            decoration: BoxDecoration(
+              color: headerBgColor,
+              borderRadius: _isExpanded
+                  ? const BorderRadius.vertical(top: Radius.circular(12))
+                  : BorderRadius.circular(12),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Row(
+                    children: [
+                      Icon(LucideIcons.settings, size: 18, color: iconColor),
+                      const SizedBox(width: 8),
+                      Flexible(
+                        child: Text(
+                          AppLocalizations.of(context)!.examConfigurationTitle,
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            color: titleColor,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(
+                  _isExpanded ? LucideIcons.chevronUp : LucideIcons.chevronDown,
+                  size: 18,
+                  color: iconColor,
+                ),
+              ],
+            ),
+          ),
+        ),
+        AnimatedSize(
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.linear,
+          child: _isExpanded
+              ? Container(
+                  padding: const EdgeInsets.fromLTRB(16, 20, 16, 16),
+                  decoration: BoxDecoration(
+                    color: bodyBgColor,
+                    borderRadius: const BorderRadius.vertical(
+                      bottom: Radius.circular(12),
+                    ),
+                    border: Border(
+                      left: BorderSide(color: borderColor),
+                      right: BorderSide(color: borderColor),
+                      bottom: BorderSide(color: borderColor),
+                    ),
+                  ),
+                  child: widget.child,
+                )
+              : const SizedBox(width: double.infinity),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/screens/dialogs/question_count_selection_dialog.dart
+++ b/lib/presentation/screens/dialogs/question_count_selection_dialog.dart
@@ -28,6 +28,7 @@ import 'package:quizdy/domain/models/quiz/quiz_config.dart';
 import 'package:quizdy/domain/models/quiz/quiz_config_stored_settings.dart';
 import 'package:quizdy/domain/models/quiz/question_order.dart';
 import 'package:quizdy/presentation/screens/dialogs/count_selection/advanced_settings_section.dart';
+import 'package:quizdy/presentation/screens/dialogs/count_selection/collapsible_exam_config.dart';
 import 'package:quizdy/presentation/screens/dialogs/count_selection/quiz_mode_selection.dart';
 import 'package:quizdy/presentation/widgets/quizdy_stepper_field.dart';
 
@@ -613,7 +614,7 @@ class _QuestionCountSelectionDialogState
                     ),
 
                     const SizedBox(height: 12),
-                    _CollapsibleExamConfig(
+                    CollapsibleExamConfig(
                       isDark: isDark,
                       child: AdvancedSettingsSection(
                         isStudyMode: _isStudyMode,
@@ -759,109 +760,6 @@ class _QuestionCountSelectionDialogState
           ],
         ),
       ),
-    );
-  }
-}
-
-class _CollapsibleExamConfig extends StatefulWidget {
-  final bool isDark;
-  final Widget child;
-
-  const _CollapsibleExamConfig({required this.isDark, required this.child});
-
-  @override
-  State<_CollapsibleExamConfig> createState() => _CollapsibleExamConfigState();
-}
-
-class _CollapsibleExamConfigState extends State<_CollapsibleExamConfig> {
-  bool _isExpanded = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final borderColor = widget.isDark
-        ? const Color(0xFF3F3F46)
-        : const Color(0xFFE4E4E7);
-    final headerBgColor = widget.isDark
-        ? const Color(0xFF3F3F46)
-        : const Color(0xFFF4F4F5);
-    final bodyBgColor = widget.isDark
-        ? const Color(0xFF1E1E22)
-        : const Color(0xFFFAFAFA);
-    final iconColor = widget.isDark
-        ? const Color(0xFFA1A1AA)
-        : const Color(0xFF71717A);
-    final titleColor = widget.isDark ? Colors.white : const Color(0xFF18181B);
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        GestureDetector(
-          onTap: () {
-            setState(() {
-              _isExpanded = !_isExpanded;
-            });
-          },
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-            decoration: BoxDecoration(
-              color: headerBgColor,
-              borderRadius: _isExpanded
-                  ? const BorderRadius.vertical(top: Radius.circular(12))
-                  : BorderRadius.circular(12),
-            ),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Expanded(
-                  child: Row(
-                    children: [
-                      Icon(LucideIcons.settings, size: 18, color: iconColor),
-                      const SizedBox(width: 8),
-                      Flexible(
-                        child: Text(
-                          AppLocalizations.of(context)!.examConfigurationTitle,
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w600,
-                            color: titleColor,
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                Icon(
-                  _isExpanded ? LucideIcons.chevronUp : LucideIcons.chevronDown,
-                  size: 18,
-                  color: iconColor,
-                ),
-              ],
-            ),
-          ),
-        ),
-        AnimatedSize(
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.linear,
-          child: _isExpanded
-              ? Container(
-                  padding: const EdgeInsets.fromLTRB(16, 20, 16, 16),
-                  decoration: BoxDecoration(
-                    color: bodyBgColor,
-                    borderRadius: const BorderRadius.vertical(
-                      bottom: Radius.circular(12),
-                    ),
-                    border: Border(
-                      left: BorderSide(color: borderColor),
-                      right: BorderSide(color: borderColor),
-                      bottom: BorderSide(color: borderColor),
-                    ),
-                  ),
-                  child: widget.child,
-                )
-              : const SizedBox(width: double.infinity),
-        ),
-      ],
     );
   }
 }

--- a/lib/presentation/screens/dialogs/settings_dialog.dart
+++ b/lib/presentation/screens/dialogs/settings_dialog.dart
@@ -25,12 +25,12 @@ import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/core/service_locator.dart';
 import 'package:quizdy/core/theme/extensions/confirm_dialog_colors_extension.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
+import 'package:quizdy/presentation/screens/dialogs/settings_dialog_widgets.dart';
 import 'package:quizdy/presentation/screens/dialogs/settings_widgets/ai_settings_section.dart';
 import 'package:quizdy/presentation/screens/dialogs/settings_widgets/advanced_settings_section.dart';
 import 'package:quizdy/presentation/utils/support_issue_helper.dart';
 import 'package:quizdy/presentation/widgets/quizdy_button.dart';
 import 'package:quizdy/presentation/widgets/quizdy_markdown.dart';
-import 'package:quizdy/routes/app_router.dart';
 
 class SettingsDialog extends StatefulWidget {
   const SettingsDialog({super.key});
@@ -480,16 +480,16 @@ class _SettingsDialogState extends State<SettingsDialog> {
                           const SizedBox(height: 24),
                           Divider(color: colors.border),
                           const SizedBox(height: 16),
-                          _OnboardingRow(colors: colors),
+                          SettingsOnboardingRow(colors: colors),
                           const SizedBox(height: 8),
-                          _PrivacyPolicyRow(colors: colors),
+                          SettingsPrivacyPolicyRow(colors: colors),
                           const SizedBox(height: 8),
-                          _SupportRow(
+                          SettingsSupportRow(
                             colors: colors,
                             onTap: _openSupportIssueUrl,
                           ),
                           const SizedBox(height: 8),
-                          _VersionRow(
+                          SettingsVersionRow(
                             colors: colors,
                             version: _appVersion,
                             onTap: _openChangelog,
@@ -513,235 +513,6 @@ class _SettingsDialogState extends State<SettingsDialog> {
                 ),
               ],
             ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _OnboardingRow extends StatelessWidget {
-  final ConfirmingDialogColorsExtension colors;
-
-  const _OnboardingRow({required this.colors});
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      borderRadius: BorderRadius.circular(12),
-      onTap: () async {
-        await ServiceLocator.getIt<ConfigurationService>()
-            .setOnboardingCompleted(false);
-        if (context.mounted) {
-          context.pop();
-          context.push('${AppRoutes.onboarding}?from=settings');
-        }
-      },
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Row(
-          children: [
-            Container(
-              width: 40,
-              height: 40,
-              decoration: BoxDecoration(
-                color: colors.surface,
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Icon(
-                LucideIcons.graduationCap,
-                size: 20,
-                color: colors.subtitle,
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    AppLocalizations.of(context)!.showOnboarding,
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      color: colors.title,
-                    ),
-                  ),
-                  Text(
-                    AppLocalizations.of(context)!.showOnboardingDescription,
-                    style: TextStyle(fontSize: 12, color: colors.subtitle),
-                  ),
-                ],
-              ),
-            ),
-            Icon(LucideIcons.chevronRight, size: 18, color: colors.subtitle),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _VersionRow extends StatelessWidget {
-  final ConfirmingDialogColorsExtension colors;
-  final String version;
-  final VoidCallback onTap;
-
-  const _VersionRow({
-    required this.colors,
-    required this.version,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      borderRadius: BorderRadius.circular(12),
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Row(
-          children: [
-            Container(
-              width: 40,
-              height: 40,
-              decoration: BoxDecoration(
-                color: colors.surface,
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Icon(LucideIcons.info, size: 20, color: colors.subtitle),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    AppLocalizations.of(context)!.versionLabel,
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      color: colors.title,
-                    ),
-                  ),
-                  Text(
-                    version,
-                    style: TextStyle(fontSize: 12, color: colors.subtitle),
-                  ),
-                ],
-              ),
-            ),
-            Icon(LucideIcons.chevronRight, size: 18, color: colors.subtitle),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _PrivacyPolicyRow extends StatelessWidget {
-  final ConfirmingDialogColorsExtension colors;
-
-  const _PrivacyPolicyRow({required this.colors});
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      borderRadius: BorderRadius.circular(12),
-      onTap: () {
-        context.pop();
-        context.push('${AppRoutes.privacyPolicy}?from=settings');
-      },
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Row(
-          children: [
-            Container(
-              width: 40,
-              height: 40,
-              decoration: BoxDecoration(
-                color: colors.surface,
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Icon(LucideIcons.shield, size: 20, color: colors.subtitle),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    AppLocalizations.of(context)!.privacyPolicyLabel,
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      color: colors.title,
-                    ),
-                  ),
-                  Text(
-                    AppLocalizations.of(context)!.privacyPolicyDescription,
-                    style: TextStyle(fontSize: 12, color: colors.subtitle),
-                  ),
-                ],
-              ),
-            ),
-            Icon(LucideIcons.chevronRight, size: 18, color: colors.subtitle),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _SupportRow extends StatelessWidget {
-  final ConfirmingDialogColorsExtension colors;
-  final VoidCallback onTap;
-
-  const _SupportRow({required this.colors, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      borderRadius: BorderRadius.circular(12),
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Row(
-          children: [
-            Container(
-              width: 40,
-              height: 40,
-              decoration: BoxDecoration(
-                color: colors.surface,
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Icon(
-                LucideIcons.lifeBuoy,
-                size: 20,
-                color: colors.subtitle,
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    AppLocalizations.of(context)!.supportLabel,
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      color: colors.title,
-                    ),
-                  ),
-                  Text(
-                    AppLocalizations.of(context)!.supportDescription,
-                    style: TextStyle(fontSize: 12, color: colors.subtitle),
-                  ),
-                ],
-              ),
-            ),
-            Icon(LucideIcons.chevronRight, size: 18, color: colors.subtitle),
           ],
         ),
       ),

--- a/lib/presentation/screens/dialogs/settings_dialog_widgets.dart
+++ b/lib/presentation/screens/dialogs/settings_dialog_widgets.dart
@@ -1,0 +1,180 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+import 'package:quizdy/core/service_locator.dart';
+import 'package:quizdy/core/theme/extensions/confirm_dialog_colors_extension.dart';
+import 'package:quizdy/data/services/configuration_service.dart';
+import 'package:quizdy/routes/app_router.dart';
+
+class SettingsOnboardingRow extends StatelessWidget {
+  final ConfirmingDialogColorsExtension colors;
+
+  const SettingsOnboardingRow({super.key, required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: () async {
+        await ServiceLocator.getIt<ConfigurationService>()
+            .setOnboardingCompleted(false);
+        if (context.mounted) {
+          context.pop();
+          context.push('${AppRoutes.onboarding}?from=settings');
+        }
+      },
+      child: _SettingsRow(
+        icon: LucideIcons.graduationCap,
+        title: AppLocalizations.of(context)!.showOnboarding,
+        description: AppLocalizations.of(context)!.showOnboardingDescription,
+        colors: colors,
+      ),
+    );
+  }
+}
+
+class SettingsVersionRow extends StatelessWidget {
+  final ConfirmingDialogColorsExtension colors;
+  final String version;
+  final VoidCallback onTap;
+
+  const SettingsVersionRow({
+    super.key,
+    required this.colors,
+    required this.version,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: onTap,
+      child: _SettingsRow(
+        icon: LucideIcons.info,
+        title: AppLocalizations.of(context)!.versionLabel,
+        description: version,
+        colors: colors,
+      ),
+    );
+  }
+}
+
+class SettingsPrivacyPolicyRow extends StatelessWidget {
+  final ConfirmingDialogColorsExtension colors;
+
+  const SettingsPrivacyPolicyRow({super.key, required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: () {
+        context.pop();
+        context.push('${AppRoutes.privacyPolicy}?from=settings');
+      },
+      child: _SettingsRow(
+        icon: LucideIcons.shield,
+        title: AppLocalizations.of(context)!.privacyPolicyLabel,
+        description: AppLocalizations.of(context)!.privacyPolicyDescription,
+        colors: colors,
+      ),
+    );
+  }
+}
+
+class SettingsSupportRow extends StatelessWidget {
+  final ConfirmingDialogColorsExtension colors;
+  final VoidCallback onTap;
+
+  const SettingsSupportRow({
+    super.key,
+    required this.colors,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: onTap,
+      child: _SettingsRow(
+        icon: LucideIcons.lifeBuoy,
+        title: AppLocalizations.of(context)!.supportLabel,
+        description: AppLocalizations.of(context)!.supportDescription,
+        colors: colors,
+      ),
+    );
+  }
+}
+
+class _SettingsRow extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String description;
+  final ConfirmingDialogColorsExtension colors;
+
+  const _SettingsRow({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.colors,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: colors.surface,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(icon, size: 20, color: colors.subtitle),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: colors.title,
+                  ),
+                ),
+                Text(
+                  description,
+                  style: TextStyle(fontSize: 12, color: colors.subtitle),
+                ),
+              ],
+            ),
+          ),
+          Icon(LucideIcons.chevronRight, size: 18, color: colors.subtitle),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/quiz_loaded_screen.dart
+++ b/lib/presentation/screens/quiz_loaded_screen.dart
@@ -50,6 +50,7 @@ import 'package:quizdy/presentation/screens/widgets/quiz_loaded_bottom_bar.dart'
 import 'package:quizdy/presentation/screens/dialogs/settings_dialog.dart';
 import 'package:quizdy/presentation/screens/widgets/common/quizdy_app_bar.dart';
 import 'package:quizdy/presentation/screens/widgets/request_file_name_dialog.dart';
+import 'package:quizdy/presentation/screens/widgets/quiz_loaded/quiz_loaded_widgets.dart';
 import 'package:quizdy/presentation/widgets/quizdy_empty_state.dart';
 import 'package:quizdy/data/services/ai/ai_question_generation_service.dart';
 import 'package:quizdy/presentation/screens/dialogs/quiz_metadata_dialog.dart';
@@ -620,164 +621,28 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
                 ],
               ),
               actions: [
-                // Study Mode Button
-                Tooltip(
-                  message: AppLocalizations.of(context)!.studyModeLabel,
-                  child: Container(
-                    margin: const EdgeInsets.only(right: 8),
-                    constraints: const BoxConstraints(minWidth: 40),
-                    child: Material(
-                      color: context.quizLoadedTheme.appBarIconBackgroundColor,
-                      borderRadius: BorderRadius.circular(20),
-                      child: InkWell(
-                        borderRadius: BorderRadius.circular(20),
-                        onTap: () {
-                          context.pushReplacement(
-                            AppRoutes.studyScreen,
-                            extra: {
-                              'initialChunks':
-                                  cachedQuizFile.study?.content.cache ?? [],
-                              'documentTitle': cachedQuizFile.metadata.title,
-                              'documentSummary':
-                                  cachedQuizFile.metadata.description,
-                              'quizFile': cachedQuizFile,
-                              'hideStartQuizButton': true,
-                            },
-                          );
-                        },
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 12,
-                            vertical: 10,
-                          ),
-                          child: Builder(
-                            builder: (context) {
-                              final showText =
-                                  MediaQuery.of(context).size.width > 500;
-                              return Row(
-                                mainAxisSize: MainAxisSize.min,
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  Icon(
-                                    LucideIcons.bookOpen,
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.onPrimary,
-                                    size: 18,
-                                  ),
-                                  if (showText) ...[
-                                    const SizedBox(width: 6),
-                                    Text(
-                                      AppLocalizations.of(
-                                        context,
-                                      )!.studyModeLabel,
-                                      style: TextStyle(
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.onPrimary,
-                                        fontSize: 13,
-                                        fontWeight: FontWeight.w600,
-                                      ),
-                                      overflow: TextOverflow.ellipsis,
-                                    ),
-                                  ],
-                                ],
-                              );
-                            },
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
+                QuizLoadedStudyModeButton(
+                  quizFile: cachedQuizFile,
+                  onTap: () {
+                    context.pushReplacement(
+                      AppRoutes.studyScreen,
+                      extra: {
+                        'initialChunks':
+                            cachedQuizFile.study?.content.cache ?? [],
+                        'documentTitle': cachedQuizFile.metadata.title,
+                        'documentSummary': cachedQuizFile.metadata.description,
+                        'quizFile': cachedQuizFile,
+                        'hideStartQuizButton': true,
+                      },
+                    );
+                  },
                 ),
-                // Settings Button
-                Container(
-                  width: 40,
-                  height: 40,
-                  margin: const EdgeInsets.only(right: 8),
-                  decoration: BoxDecoration(
-                    color: context.quizLoadedTheme.appBarIconBackgroundColor,
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: IconButton(
-                    padding: EdgeInsets.zero,
-                    onPressed: () => _showSettingsDialog(context),
-                    icon: Icon(
-                      LucideIcons.settings,
-                      color: Theme.of(context).colorScheme.onPrimary,
-                      size: 20,
-                    ),
-                    tooltip: AppLocalizations.of(context)!.settingsTitle,
-                  ),
+                QuizLoadedSettingsButton(
+                  onTap: () => _showSettingsDialog(context),
                 ),
-                Container(
-                  margin: const EdgeInsets.only(right: 24),
-                  constraints: const BoxConstraints(minWidth: 40),
-                  child: Tooltip(
-                    message: _isSelectionMode
-                        ? AppLocalizations.of(context)!.done
-                        : AppLocalizations.of(context)!.select,
-                    child: Material(
-                      color: context
-                          .quizLoadedTheme
-                          .selectionInactiveBackgroundColor,
-                      borderRadius: BorderRadius.circular(12),
-                      child: InkWell(
-                        borderRadius: BorderRadius.circular(12),
-                        onTap: () {
-                          _toggleSelectionMode();
-                        },
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 12,
-                            vertical: 10,
-                          ),
-                          child: Builder(
-                            builder: (context) {
-                              final showText =
-                                  MediaQuery.of(context).size.width > 500;
-
-                              return Row(
-                                mainAxisSize: MainAxisSize.min,
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  Icon(
-                                    _isSelectionMode
-                                        ? LucideIcons.checkSquare
-                                        : LucideIcons.mousePointer2,
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.onPrimary,
-                                    size: 18,
-                                  ),
-                                  if (showText) ...[
-                                    const SizedBox(width: 8),
-                                    Flexible(
-                                      child: Text(
-                                        _isSelectionMode
-                                            ? AppLocalizations.of(context)!.done
-                                            : AppLocalizations.of(
-                                                context,
-                                              )!.select,
-                                        style: TextStyle(
-                                          color: Theme.of(
-                                            context,
-                                          ).colorScheme.onPrimary,
-                                          fontSize: 13,
-                                          fontWeight: FontWeight.w600,
-                                        ),
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                    ),
-                                  ],
-                                ],
-                              );
-                            },
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
+                QuizLoadedSelectionToggleButton(
+                  isSelectionMode: _isSelectionMode,
+                  onTap: _toggleSelectionMode,
                 ),
               ],
             ),
@@ -840,56 +705,7 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
                         },
                       ),
                     ),
-                  if (_isDragging)
-                    Positioned.fill(
-                      child: Container(
-                        color: context.quizLoadedTheme.dragOverlayColor,
-                        child: Center(
-                          child: Container(
-                            padding: const EdgeInsets.all(32),
-                            decoration: BoxDecoration(
-                              color: Theme.of(context).cardColor,
-                              borderRadius: BorderRadius.circular(24),
-                              border: Border.all(
-                                color: context
-                                    .quizLoadedTheme
-                                    .dragOverlayBorderColor,
-                                width: 3,
-                              ),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: context
-                                      .quizLoadedTheme
-                                      .dragOverlayShadowColor,
-                                  blurRadius: 20,
-                                  offset: const Offset(0, 10),
-                                ),
-                              ],
-                            ),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Icon(
-                                  LucideIcons.upload,
-                                  size: 48,
-                                  color: Theme.of(context).primaryColor,
-                                ),
-                                const SizedBox(height: 16),
-                                Text(
-                                  AppLocalizations.of(context)!.dropFileHere,
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .headlineMedium
-                                      ?.copyWith(
-                                        color: Theme.of(context).primaryColor,
-                                      ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
+                  if (_isDragging) const QuizLoadedDragOverlay(),
                 ],
               ),
             ),

--- a/lib/presentation/screens/widgets/quiz_loaded/quiz_loaded_widgets.dart
+++ b/lib/presentation/screens/widgets/quiz_loaded/quiz_loaded_widgets.dart
@@ -1,0 +1,229 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+import 'package:quizdy/core/theme/extensions/quiz_loaded_theme.dart';
+import 'package:quizdy/domain/models/quiz/quiz_file.dart';
+
+class QuizLoadedDragOverlay extends StatelessWidget {
+  const QuizLoadedDragOverlay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: Container(
+        color: context.quizLoadedTheme.dragOverlayColor,
+        child: Center(
+          child: Container(
+            padding: const EdgeInsets.all(32),
+            decoration: BoxDecoration(
+              color: Theme.of(context).cardColor,
+              borderRadius: BorderRadius.circular(24),
+              border: Border.all(
+                color: context.quizLoadedTheme.dragOverlayBorderColor,
+                width: 3,
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: context.quizLoadedTheme.dragOverlayShadowColor,
+                  blurRadius: 20,
+                  offset: const Offset(0, 10),
+                ),
+              ],
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  LucideIcons.upload,
+                  size: 48,
+                  color: Theme.of(context).primaryColor,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  AppLocalizations.of(context)!.dropFileHere,
+                  style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                    color: Theme.of(context).primaryColor,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class QuizLoadedStudyModeButton extends StatelessWidget {
+  final QuizFile quizFile;
+  final VoidCallback onTap;
+
+  const QuizLoadedStudyModeButton({
+    super.key,
+    required this.quizFile,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: AppLocalizations.of(context)!.studyModeLabel,
+      child: Container(
+        margin: const EdgeInsets.only(right: 8),
+        constraints: const BoxConstraints(minWidth: 40),
+        child: Material(
+          color: context.quizLoadedTheme.appBarIconBackgroundColor,
+          borderRadius: BorderRadius.circular(20),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(20),
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              child: Builder(
+                builder: (context) {
+                  final showText = MediaQuery.of(context).size.width > 500;
+                  return Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        LucideIcons.bookOpen,
+                        color: Theme.of(context).colorScheme.onPrimary,
+                        size: 18,
+                      ),
+                      if (showText) ...[
+                        const SizedBox(width: 6),
+                        Text(
+                          AppLocalizations.of(context)!.studyModeLabel,
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.onPrimary,
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class QuizLoadedSettingsButton extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const QuizLoadedSettingsButton({super.key, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 40,
+      margin: const EdgeInsets.only(right: 8),
+      decoration: BoxDecoration(
+        color: context.quizLoadedTheme.appBarIconBackgroundColor,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: IconButton(
+        padding: EdgeInsets.zero,
+        onPressed: onTap,
+        icon: Icon(
+          LucideIcons.settings,
+          color: Theme.of(context).colorScheme.onPrimary,
+          size: 20,
+        ),
+        tooltip: AppLocalizations.of(context)!.settingsTitle,
+      ),
+    );
+  }
+}
+
+class QuizLoadedSelectionToggleButton extends StatelessWidget {
+  final bool isSelectionMode;
+  final VoidCallback onTap;
+
+  const QuizLoadedSelectionToggleButton({
+    super.key,
+    required this.isSelectionMode,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(right: 24),
+      constraints: const BoxConstraints(minWidth: 40),
+      child: Tooltip(
+        message: isSelectionMode
+            ? AppLocalizations.of(context)!.done
+            : AppLocalizations.of(context)!.select,
+        child: Material(
+          color: context.quizLoadedTheme.selectionInactiveBackgroundColor,
+          borderRadius: BorderRadius.circular(12),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(12),
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              child: Builder(
+                builder: (context) {
+                  final showText = MediaQuery.of(context).size.width > 500;
+                  return Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        isSelectionMode
+                            ? LucideIcons.checkSquare
+                            : LucideIcons.mousePointer2,
+                        color: Theme.of(context).colorScheme.onPrimary,
+                        size: 18,
+                      ),
+                      if (showText) ...[
+                        const SizedBox(width: 8),
+                        Flexible(
+                          child: Text(
+                            isSelectionMode
+                                ? AppLocalizations.of(context)!.done
+                                : AppLocalizations.of(context)!.select,
+                            style: TextStyle(
+                              color: Theme.of(context).colorScheme.onPrimary,
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/widgets/study/study_body.dart
+++ b/lib/presentation/screens/widgets/study/study_body.dart
@@ -14,7 +14,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lucide_icons/lucide_icons.dart';
 import 'package:quizdy/core/context_extension.dart';
 import 'package:quizdy/core/extensions/string_extension.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
@@ -30,10 +29,10 @@ import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_e
 import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_state.dart';
 import 'package:quizdy/presentation/screens/dialogs/custom_confirm_dialog.dart';
 import 'package:quizdy/presentation/screens/quiz_execution/widgets/ai_studio_chat_side_panel.dart';
-import 'package:quizdy/presentation/screens/widgets/study/components/study_component_builder.dart';
 import 'package:quizdy/presentation/screens/widgets/study/study_index_view.dart';
 import 'package:quizdy/presentation/screens/widgets/study/study_sections_sidebar.dart';
 import 'package:quizdy/presentation/screens/widgets/study/add_edit_chunk_dialog.dart';
+import 'package:quizdy/presentation/screens/widgets/study/study_content_view.dart';
 import 'package:quizdy/presentation/widgets/quizdy_loading.dart';
 import 'package:quizdy/routes/app_router.dart';
 import 'package:go_router/go_router.dart';
@@ -327,22 +326,11 @@ class _StudyBodyState extends State<StudyBody>
 
               final currentChunk = state.currentChunk;
               if (currentChunk == null) {
-                return Center(
-                  child: Text(localizations.studyScreenNoSlidesAvailable),
-                );
+                return StudyNoChunkAvailable(localizations: localizations);
               }
 
               if (currentChunk.status == StudyChunkState.processing) {
-                return Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const QuizdyLoading(),
-                      const SizedBox(height: 16),
-                      Text(localizations.studyScreenGenerating),
-                    ],
-                  ),
-                );
+                return StudyGeneratingContent(localizations: localizations);
               }
 
               final isChunkReady =
@@ -472,63 +460,16 @@ class _StudyBodyState extends State<StudyBody>
 
                   final mainContent = Stack(
                     children: [
-                      Padding(
-                        padding: const EdgeInsets.only(left: 16.0),
-                        child: Column(
-                          children: [
-                            Expanded(
-                              child:
-                                  currentChunk.status == StudyChunkState.error
-                                  ? const SizedBox.shrink()
-                                  : (currentChunk.pages.isNotEmpty
-                                        ? ListView.builder(
-                                            key: ValueKey(
-                                              state.currentChunkIndex,
-                                            ),
-                                            itemCount:
-                                                currentChunk.pages.length,
-                                            itemBuilder: (context, index) {
-                                              final page =
-                                                  currentChunk.pages[index];
-                                              return Card(
-                                                margin: const EdgeInsets.only(
-                                                  bottom: 16,
-                                                ),
-                                                child: Padding(
-                                                  padding: const EdgeInsets.all(
-                                                    16,
-                                                  ),
-                                                  child: Column(
-                                                    crossAxisAlignment:
-                                                        CrossAxisAlignment
-                                                            .start,
-                                                    children: page.uiElements.map((
-                                                      element,
-                                                    ) {
-                                                      return StudyComponentBuilder(
-                                                        element: element,
-                                                      );
-                                                    }).toList(),
-                                                  ),
-                                                ),
-                                              );
-                                            },
-                                          )
-                                        : Center(
-                                            child: Text(
-                                              localizations
-                                                  .studyScreenNoSlidesGenerated,
-                                            ),
-                                          )),
-                            ),
-                          ],
-                        ),
+                      StudyContentView(
+                        currentChunk: currentChunk,
+                        currentChunkIndex: state.currentChunkIndex,
+                        localizations: localizations,
                       ),
                       if (!_isSidebarOpen)
                         Positioned(
                           top: MediaQuery.of(context).padding.top + 12,
                           left: 12,
-                          child: _SidebarOpenButton(
+                          child: SidebarOpenButton(
                             isDark: isDark,
                             onTap: _openSidebar,
                           ),
@@ -537,7 +478,7 @@ class _StudyBodyState extends State<StudyBody>
                         Positioned(
                           top: MediaQuery.of(context).padding.top + 12,
                           right: 12,
-                          child: _AskAiButton(
+                          child: AskAiButton(
                             isDark: isDark,
                             isAiAvailable: _isAiAvailable,
                             tooltip: localizations.askAIStudyTooltip,
@@ -625,81 +566,10 @@ class _StudyBodyState extends State<StudyBody>
                 return const SizedBox.shrink();
               }
 
-              return Positioned.fill(
-                child: Container(
-                  color: Colors.black.withValues(alpha: 0.1),
-                  child: const Center(child: QuizdyLoading()),
-                ),
-              );
+              return const StudyLoadingOverlay();
             },
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _SidebarOpenButton extends StatelessWidget {
-  final bool isDark;
-  final VoidCallback onTap;
-
-  const _SidebarOpenButton({required this.isDark, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        width: 32,
-        height: 32,
-        decoration: BoxDecoration(
-          color: isDark ? AppTheme.zinc700 : AppTheme.zinc100,
-          borderRadius: BorderRadius.circular(16),
-        ),
-        alignment: Alignment.center,
-        child: Icon(
-          LucideIcons.panelRightClose,
-          size: 18,
-          color: isDark ? AppTheme.zinc400 : AppTheme.zinc500,
-        ),
-      ),
-    );
-  }
-}
-
-class _AskAiButton extends StatelessWidget {
-  final bool isDark;
-  final bool isAiAvailable;
-  final String tooltip;
-  final VoidCallback onTap;
-
-  const _AskAiButton({
-    required this.isDark,
-    required this.isAiAvailable,
-    required this.tooltip,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Tooltip(
-      message: tooltip,
-      child: GestureDetector(
-        onTap: onTap,
-        child: Container(
-          width: 36,
-          height: 36,
-          decoration: BoxDecoration(
-            color: isDark ? AppTheme.zinc700 : AppTheme.zinc100,
-            borderRadius: BorderRadius.circular(18),
-          ),
-          alignment: Alignment.center,
-          child: Icon(
-            LucideIcons.sparkles,
-            size: 18,
-            color: Theme.of(context).primaryColor,
-          ),
-        ),
       ),
     );
   }

--- a/lib/presentation/screens/widgets/study/study_content_view.dart
+++ b/lib/presentation/screens/widgets/study/study_content_view.dart
@@ -1,0 +1,193 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:quizdy/core/theme/app_theme.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+import 'package:quizdy/domain/models/quiz/study_chunk_state.dart';
+import 'package:quizdy/domain/models/quiz/study_chunk.dart';
+import 'package:quizdy/presentation/screens/widgets/study/components/study_component_builder.dart';
+
+class StudyContentView extends StatelessWidget {
+  final StudyChunk currentChunk;
+  final int currentChunkIndex;
+  final AppLocalizations localizations;
+
+  const StudyContentView({
+    super.key,
+    required this.currentChunk,
+    required this.currentChunkIndex,
+    required this.localizations,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 16.0),
+      child: Column(
+        children: [
+          Expanded(
+            child: currentChunk.status == StudyChunkState.error
+                ? const SizedBox.shrink()
+                : (currentChunk.pages.isNotEmpty
+                      ? ListView.builder(
+                          key: ValueKey(currentChunkIndex),
+                          itemCount: currentChunk.pages.length,
+                          itemBuilder: (context, index) {
+                            final page = currentChunk.pages[index];
+                            return Card(
+                              margin: const EdgeInsets.only(bottom: 16),
+                              child: Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: page.uiElements.map((element) {
+                                    return StudyComponentBuilder(
+                                      element: element,
+                                    );
+                                  }).toList(),
+                                ),
+                              ),
+                            );
+                          },
+                        )
+                      : Center(
+                          child: Text(
+                            localizations.studyScreenNoSlidesGenerated,
+                          ),
+                        )),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class StudyLoadingOverlay extends StatelessWidget {
+  const StudyLoadingOverlay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: Container(
+        color: Colors.black.withValues(alpha: 0.1),
+        child: const Center(child: CircularProgressIndicator()),
+      ),
+    );
+  }
+}
+
+class StudyNoChunkAvailable extends StatelessWidget {
+  final AppLocalizations localizations;
+
+  const StudyNoChunkAvailable({super.key, required this.localizations});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(child: Text(localizations.studyScreenNoSlidesAvailable));
+  }
+}
+
+class StudyGeneratingContent extends StatelessWidget {
+  final AppLocalizations localizations;
+
+  const StudyGeneratingContent({super.key, required this.localizations});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: 16),
+          Text(localizations.studyScreenGenerating),
+        ],
+      ),
+    );
+  }
+}
+
+class SidebarOpenButton extends StatelessWidget {
+  final bool isDark;
+  final VoidCallback onTap;
+
+  const SidebarOpenButton({
+    super.key,
+    required this.isDark,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          color: isDark ? AppTheme.zinc700 : AppTheme.zinc100,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        alignment: Alignment.center,
+        child: Icon(
+          LucideIcons.panelRightClose,
+          size: 18,
+          color: isDark ? AppTheme.zinc400 : AppTheme.zinc500,
+        ),
+      ),
+    );
+  }
+}
+
+class AskAiButton extends StatelessWidget {
+  final bool isDark;
+  final bool isAiAvailable;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  const AskAiButton({
+    super.key,
+    required this.isDark,
+    required this.isAiAvailable,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          width: 36,
+          height: 36,
+          decoration: BoxDecoration(
+            color: isDark ? AppTheme.zinc700 : AppTheme.zinc100,
+            borderRadius: BorderRadius.circular(18),
+          ),
+          alignment: Alignment.center,
+          child: Icon(
+            LucideIcons.sparkles,
+            size: 18,
+            color: Theme.of(context).primaryColor,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Refactored 3 large presentation layer files to extract reusable widgets, reducing code duplication and improving maintainability.
## Changes
### 1. `lib/presentation/screens/widgets/study/study_content_view.dart` (NEW FILE)
Extracted from `study_body.dart`:
- `StudyContentView` - Displays study content with ListView
- `StudyLoadingOverlay` - Loading overlay with semi-transparent background
- `StudyNoChunkAvailable` - Empty state when no content available
- `StudyGeneratingContent` - Loading state during AI generation
- `SidebarOpenButton` - Button to open study sections sidebar
- `AskAiButton` - Button to open AI chat panel
### 2. `lib/presentation/screens/widgets/quiz_loaded/quiz_loaded_widgets.dart` (NEW FILE)
Extracted from `quiz_loaded_screen.dart`:
- `QuizLoadedDragOverlay` - Drag-and-drop overlay for importing files
- `QuizLoadedStudyModeButton` - Study mode navigation button with responsive text
- `QuizLoadedSettingsButton` - Settings icon button
- `QuizLoadedSelectionToggleButton` - Toggle button for question selection mode
### 3. `lib/presentation/screens/dialogs/count_selection/collapsible_exam_config.dart` (NEW FILE)
Extracted from `question_count_selection_dialog.dart`:
- `CollapsibleExamConfig` - Collapsible section for exam configuration settings
### 4. `lib/presentation/screens/dialogs/settings_dialog_widgets.dart` (NEW FILE)
Extracted from `settings_dialog.dart`:
- `SettingsOnboardingRow` - Onboarding reset row
- `SettingsVersionRow` - Version info row
- `SettingsPrivacyPolicyRow` - Privacy policy navigation row
- `SettingsSupportRow` - Support page navigation row
- `_SettingsRow` (private) - Reusable base widget for settings rows