### PR TITLE
feat(pdf): add export options dialog with questions, answers and study toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.13.0] - TBD
 
 - feat: Implemented `CardStatusBar` and applied for `StudyIndexChunkCard` and `QuestionPreviewCard`.
+- feat(pdf): add export options dialog with questions, answers and study toggles.
 
 ## [1.12.0] - 2026-04-17
 

--- a/lib/core/l10n/app_ar.arb
+++ b/lib/core/l10n/app_ar.arb
@@ -2743,5 +2743,45 @@
   "studyPdfTableOfContents": "جدول المحتويات",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "تضمين الدراسة",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "إضافة صفحات محتوى الدراسة",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "تصدير كـ PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "تضمين صفحة الأسئلة",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "إضافة صفحة بجميع أسئلة الاختبار",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "تضمين الإجابات",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "إضافة صفحة منفصلة بالإجابات الصحيحة",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "الأسئلة",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "الإجابات",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "تصدير",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_ca.arb
+++ b/lib/core/l10n/app_ca.arb
@@ -2431,5 +2431,45 @@
   "studyPdfTableOfContents": "Taula de continguts",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "Incloure estudi",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Afegir les pàgines de contingut d'estudi",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Exportar com a PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Incloure pàgina de preguntes",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Afegir una pàgina amb totes les preguntes del qüestionari",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Incloure respostes",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Afegir una pàgina separada amb les respostes correctes",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Preguntes",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Respostes",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Exportar",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -2425,5 +2425,45 @@
   "studyPdfTableOfContents": "Inhaltsverzeichnis",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "Studieninhalt einschließen",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Studieninhaltsseiten hinzufügen",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Als PDF exportieren",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Frageseite einschließen",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Eine Seite mit allen Quizfragen hinzufügen",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Antworten einschließen",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Eine separate Seite mit den richtigen Antworten hinzufügen",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Fragen",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Antworten",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Exportieren",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_el.arb
+++ b/lib/core/l10n/app_el.arb
@@ -1329,5 +1329,45 @@
   "studyPdfTableOfContents": "Πίνακας περιεχομένων",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "Συμπερίληψη μελέτης",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Προσθήκη σελίδων περιεχομένου μελέτης",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Εξαγωγή ως PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Συμπερίληψη σελίδας ερωτήσεων",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Προσθήκη σελίδας με όλες τις ερωτήσεις του κουίζ",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Συμπερίληψη απαντήσεων",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Προσθήκη ξεχωριστής σελίδας με τις σωστές απαντήσεις",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Ερωτήσεις",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Απαντήσεις",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Εξαγωγή",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -2805,5 +2805,45 @@
   "exportPdfError": "Failed to export PDF",
   "@exportPdfError": {
     "description": "Snackbar message shown when the PDF export fails"
+  },
+  "exportPdfOptionsIncludeStudy": "Include study",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Add the study content pages",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Export as PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Include questions page",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Add a page with all quiz questions",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Include answers",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Add a separate page with the correct answers",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Questions",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Answers",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Export",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_es.arb
+++ b/lib/core/l10n/app_es.arb
@@ -2568,5 +2568,45 @@
   "onboardingDownloadWindowsStoreButton": "Microsoft Store",
   "onboardingDownloadLinuxStoreButton": "Snapcraft",
   "onboardingDownloadQrTitle": "Escanea para continuar",
-  "onboardingDownloadQrDescription": "Usa la cámara de tu teléfono para abrir el enlace de la tienda."
+  "onboardingDownloadQrDescription": "Usa la cámara de tu teléfono para abrir el enlace de la tienda.",
+  "exportPdfOptionsIncludeStudy": "Incluir estudio",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Añadir las páginas de contenido de estudio",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Exportar como PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Incluir página de preguntas",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Añadir una página con todas las preguntas del quiz",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Incluir respuestas",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Añadir una página separada con las respuestas correctas",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Preguntas",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Respuestas",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Exportar",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
+  }
 }

--- a/lib/core/l10n/app_eu.arb
+++ b/lib/core/l10n/app_eu.arb
@@ -2329,5 +2329,45 @@
   "studyPdfTableOfContents": "Aurkibidea",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "Ikasketa sartu",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Ikasketa edukiaren orrialdeak gehitu",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "PDF gisa esportatu",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Galdera-orria sartu",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Galdetegiko galdera guztiekin orrialde bat gehitu",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Erantzunak sartu",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Erantzun zuzenekin orrialde bereizi bat gehitu",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Galderak",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Erantzunak",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Esportatu",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_fr.arb
+++ b/lib/core/l10n/app_fr.arb
@@ -2374,5 +2374,45 @@
   "studyPdfTableOfContents": "Table des matières",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "Inclure l'étude",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Ajouter les pages de contenu d'étude",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Exporter en PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Inclure la page des questions",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Ajouter une page avec toutes les questions du quiz",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Inclure les réponses",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Ajouter une page séparée avec les bonnes réponses",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Questions",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Réponses",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Exporter",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_gl.arb
+++ b/lib/core/l10n/app_gl.arb
@@ -2329,5 +2329,45 @@
   "studyPdfTableOfContents": "Táboa de contidos",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "Incluír estudo",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Engadir as páxinas de contido de estudo",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Exportar como PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Incluír páxina de preguntas",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Engadir unha páxina con todas as preguntas do quiz",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Incluír respostas",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Engadir unha páxina separada coas respostas correctas",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Preguntas",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Respostas",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Exportar",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_hi.arb
+++ b/lib/core/l10n/app_hi.arb
@@ -2332,5 +2332,45 @@
   "studyPdfTableOfContents": "विषय सूची",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "अध्ययन शामिल करें",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "अध्ययन सामग्री पृष्ठ जोड़ें",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "PDF के रूप में निर्यात करें",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "प्रश्न पृष्ठ शामिल करें",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "सभी प्रश्नोत्तरी प्रश्नों के साथ एक पृष्ठ जोड़ें",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "उत्तर शामिल करें",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "सही उत्तरों के साथ एक अलग पृष्ठ जोड़ें",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "प्रश्न",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "उत्तर",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "निर्यात",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_it.arb
+++ b/lib/core/l10n/app_it.arb
@@ -2383,5 +2383,46 @@
   "studyPdfTableOfContents": "Indice",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "Includi studio",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Aggiungi le pagine del contenuto di studio",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Esporta come PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Includi pagina delle domande",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Aggiungi una pagina con tutte le domande del quiz",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Includi risposte",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Aggiungi una pagina separata con le risposte corrette",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Domande",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Risposte",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Esporta",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
+
 }

--- a/lib/core/l10n/app_ja.arb
+++ b/lib/core/l10n/app_ja.arb
@@ -2332,5 +2332,46 @@
   "studyPdfTableOfContents": "目次",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "学習内容を含める",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "学習コンテンツページを追加する",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "PDFとして書き出す",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "問題ページを含める",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "すべてのクイズ問題を含むページを追加する",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "解答を含める",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "正解を含む別のページを追加する",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "問題",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "解答",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "書き出す",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
+
 }

--- a/lib/core/l10n/app_ka.arb
+++ b/lib/core/l10n/app_ka.arb
@@ -1021,5 +1021,45 @@
   "studyPdfTableOfContents": "სარჩევი",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "სწავლის ჩართვა",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "სასწავლო შინაარსის გვერდების დამატება",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "PDF-ის სახით ექსპორტი",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "კითხვების გვერდის ჩართვა",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "ტესტის ყველა კითხვის შემცველი გვერდის დამატება",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "პასუხების ჩართვა",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "სწორი პასუხების ცალკე გვერდის დამატება",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "კითხვები",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "პასუხები",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "ექსპორტი",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_ko.arb
+++ b/lib/core/l10n/app_ko.arb
@@ -1021,5 +1021,45 @@
   "studyPdfTableOfContents": "목차",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "학습 포함",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "학습 콘텐츠 페이지 추가",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "PDF로 내보내기",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "질문 페이지 포함",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "모든 퀴즈 질문이 포함된 페이지 추가",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "답변 포함",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "정답이 포함된 별도의 페이지 추가",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "질문",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "답변",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "내보내기",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
 }

--- a/lib/core/l10n/app_pt.arb
+++ b/lib/core/l10n/app_pt.arb
@@ -2420,5 +2420,46 @@
   "studyPdfTableOfContents": "Sumário",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "Incluir estudo",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Adicionar as páginas de conteúdo de estudo",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Exportar como PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Incluir página de perguntas",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Adicionar uma página com todas as perguntas do quiz",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Incluir respostas",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Adicionar uma página separada com as respostas corretas",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Perguntas",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Respostas",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Exportar",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
+
 }

--- a/lib/core/l10n/app_ru.arb
+++ b/lib/core/l10n/app_ru.arb
@@ -1036,5 +1036,46 @@
   "studyPdfTableOfContents": "Оглавление",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "Включить обучение",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Добавить страницы с обучающим контентом",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Экспорт в PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Включить страницу с вопросами",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Добавить страницу со всеми вопросами теста",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Включить ответы",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Добавить отдельную страницу с правильными ответами",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Вопросы",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Ответы",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Экспорт",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
+
 }

--- a/lib/core/l10n/app_uk.arb
+++ b/lib/core/l10n/app_uk.arb
@@ -1054,5 +1054,46 @@
   "studyPdfTableOfContents": "Зміст",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "Включити навчання",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "Додати сторінки з навчальним контентом",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "Експорт у PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "Включити сторінку з питаннями",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "Додати сторінку з усіма питаннями тесту",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "Включити відповіді",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "Додати окрему сторінку з правильними відповідями",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "Питання",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "Відповіді",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "Експорт",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
+
 }

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -2381,5 +2381,46 @@
   "studyPdfTableOfContents": "目录",
   "@studyPdfTableOfContents": {
     "description": "Title of the table of contents page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudy": "包含学习内容",
+  "@exportPdfOptionsIncludeStudy": {
+    "description": "Switch label to include the study content pages in the exported PDF"
+  },
+  "exportPdfOptionsIncludeStudySubtitle": "添加学习内容页面",
+  "@exportPdfOptionsIncludeStudySubtitle": {
+    "description": "Subtitle for the include study switch in the export PDF dialog"
+  },
+  "exportPdfOptionsTitle": "导出为 PDF",
+  "@exportPdfOptionsTitle": {
+    "description": "Title of the export PDF options dialog"
+  },
+  "exportPdfOptionsIncludeQuestions": "包含问题页面",
+  "@exportPdfOptionsIncludeQuestions": {
+    "description": "Switch label to include a questions page in the exported PDF"
+  },
+  "exportPdfOptionsIncludeQuestionsSubtitle": "添加包含所有测验问题的页面",
+  "@exportPdfOptionsIncludeQuestionsSubtitle": {
+    "description": "Subtitle for the include questions switch in the export PDF dialog"
+  },
+  "exportPdfOptionsIncludeAnswers": "包含答案",
+  "@exportPdfOptionsIncludeAnswers": {
+    "description": "Switch label to include correct answers in the questions page"
+  },
+  "exportPdfOptionsIncludeAnswersSubtitle": "添加包含正确答案的单独页面",
+  "@exportPdfOptionsIncludeAnswersSubtitle": {
+    "description": "Subtitle for the include answers switch in the export PDF dialog"
+  },
+  "exportPdfQuestionsPageTitle": "问题",
+  "@exportPdfQuestionsPageTitle": {
+    "description": "Section title for the questions page in the exported PDF"
+  },
+  "exportPdfAnswersLabel": "答案",
+  "@exportPdfAnswersLabel": {
+    "description": "Title of the answers page in the exported PDF"
+  },
+  "exportButton": "导出",
+  "@exportButton": {
+    "description": "Label for the Export button in the export PDF options dialog"
   }
+
 }

--- a/lib/data/services/pdf_export_generator.dart
+++ b/lib/data/services/pdf_export_generator.dart
@@ -16,6 +16,7 @@
 import 'package:flutter/services.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
+import 'package:quizdy/domain/models/quiz/question.dart';
 import 'package:quizdy/domain/models/quiz/study_chunk.dart';
 import 'package:quizdy/domain/models/quiz/study_chunk_state.dart';
 import 'package:quizdy/domain/models/quiz/study_component.dart';
@@ -26,6 +27,8 @@ class _PdfContext {
   final String advantages;
   final String limitations;
   final String tableOfContents;
+  final String questionsPageTitle;
+  final String answersLabel;
 
   /// Maps raw equation strings to pre-rendered PNG bytes captured via
   /// [LaTeXImageRenderer]. When an entry is present the equation is embedded
@@ -36,6 +39,8 @@ class _PdfContext {
     required this.advantages,
     required this.limitations,
     required this.tableOfContents,
+    this.questionsPageTitle = 'Questions',
+    this.answersLabel = 'Answer',
     this.latexImages = const {},
   });
 }
@@ -61,11 +66,17 @@ class StudyPdfGenerator {
     String limitationsLabel = 'Limitations',
     String tableOfContentsLabel = 'Table of Contents',
     Map<String, Uint8List> latexImages = const {},
+    List<Question> questions = const [],
+    bool includeAnswers = false,
+    String questionsPageTitle = 'Questions',
+    String answersLabel = 'Answer',
   }) async {
     final labels = _PdfContext(
       advantages: advantagesLabel,
       limitations: limitationsLabel,
       tableOfContents: tableOfContentsLabel,
+      questionsPageTitle: questionsPageTitle,
+      answersLabel: answersLabel,
       latexImages: latexImages,
     );
 
@@ -153,7 +164,7 @@ class StudyPdfGenerator {
     // added to the processing queue last so all Outline entries are resolved.
     // pw.TableOfContent uses DelayedWidget internally to read page numbers
     // after the full document outline is built.
-    if (readyChunks.isNotEmpty) {
+    if (readyChunks.isNotEmpty || questions.isNotEmpty) {
       pdf.addPage(
         pw.Page(
           pageTheme: pageTheme,
@@ -186,12 +197,241 @@ class StudyPdfGenerator {
       );
     }
 
+    // Questions page: appended at the end when requested.
+    if (questions.isNotEmpty) {
+      pdf.addPage(
+        pw.MultiPage(
+          pageTheme: pageTheme,
+          footer: buildFooter,
+          build: (pw.Context context) =>
+              _buildQuestionsPage(questions, labels, latexImages),
+        ),
+      );
+    }
+
+    // Answers page: separate page after questions when requested.
+    if (questions.isNotEmpty && includeAnswers) {
+      pdf.addPage(
+        pw.MultiPage(
+          pageTheme: pageTheme,
+          footer: buildFooter,
+          build: (pw.Context context) =>
+              _buildAnswersPage(questions, labels, latexImages),
+        ),
+      );
+    }
+
     return pdf.save();
   }
 
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
+
+  static List<pw.Widget> _buildQuestionsPage(
+    List<Question> questions,
+    _PdfContext labels,
+    Map<String, Uint8List> latexImages,
+  ) {
+    final widgets = <pw.Widget>[
+      pw.Outline(
+        name: 'questions_section',
+        title: labels.questionsPageTitle,
+        level: 0,
+        child: pw.Text(
+          labels.questionsPageTitle,
+          style: pw.TextStyle(fontSize: 20, fontWeight: pw.FontWeight.bold),
+        ),
+      ),
+      pw.SizedBox(height: 8),
+      pw.Divider(thickness: 2, color: PdfColors.grey600),
+      pw.SizedBox(height: 16),
+    ];
+
+    for (int i = 0; i < questions.length; i++) {
+      final q = questions[i];
+      widgets.add(
+        pw.Padding(
+          padding: const pw.EdgeInsets.only(bottom: 12),
+          child: pw.Column(
+            crossAxisAlignment: pw.CrossAxisAlignment.start,
+            children: [
+              pw.Text(
+                '${i + 1}. ${_strip(q.text)}',
+                style:
+                    pw.TextStyle(fontSize: 11, fontWeight: pw.FontWeight.bold),
+              ),
+              ..._inlineEquationWidgets(q.text, latexImages),
+              if (q.options.isNotEmpty) ...[
+                pw.SizedBox(height: 4),
+                ...List.generate(q.options.length, (j) {
+                  final label = String.fromCharCode(65 + j); // A, B, C…
+                  return pw.Column(
+                    crossAxisAlignment: pw.CrossAxisAlignment.start,
+                    children: [
+                      pw.Padding(
+                        padding: const pw.EdgeInsets.only(left: 16, bottom: 2),
+                        child: pw.Row(
+                          crossAxisAlignment: pw.CrossAxisAlignment.start,
+                          children: [
+                            pw.Text(
+                              '$label. ',
+                              style: const pw.TextStyle(fontSize: 10),
+                            ),
+                            pw.Expanded(
+                              child: pw.Text(
+                                _strip(q.options[j]),
+                                style: const pw.TextStyle(fontSize: 10),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      ..._inlineEquationWidgets(
+                        q.options[j],
+                        latexImages,
+                        paddingLeft: 32,
+                      ),
+                    ],
+                  );
+                }),
+              ],
+            ],
+          ),
+        ),
+      );
+    }
+
+    return widgets;
+  }
+
+  static List<pw.Widget> _buildAnswersPage(
+    List<Question> questions,
+    _PdfContext labels,
+    Map<String, Uint8List> latexImages,
+  ) {
+    final widgets = <pw.Widget>[
+      pw.Outline(
+        name: 'answers_section',
+        title: labels.answersLabel,
+        level: 0,
+        child: pw.Text(
+          labels.answersLabel,
+          style: pw.TextStyle(fontSize: 20, fontWeight: pw.FontWeight.bold),
+        ),
+      ),
+      pw.SizedBox(height: 8),
+      pw.Divider(thickness: 2, color: PdfColors.grey600),
+      pw.SizedBox(height: 16),
+    ];
+
+    for (int i = 0; i < questions.length; i++) {
+      final q = questions[i];
+      final correctLabels = q.correctAnswers
+          .where((idx) => idx < q.options.length)
+          .map(
+            (idx) =>
+                '${String.fromCharCode(65 + idx)}. ${_strip(q.options[idx])}',
+          )
+          .toList();
+
+      widgets.add(
+        pw.Padding(
+          padding: const pw.EdgeInsets.only(bottom: 10),
+          child: pw.Row(
+            crossAxisAlignment: pw.CrossAxisAlignment.start,
+            children: [
+              pw.Text(
+                '${i + 1}. ',
+                style:
+                    pw.TextStyle(fontSize: 10, fontWeight: pw.FontWeight.bold),
+              ),
+              pw.Expanded(
+                child: pw.Column(
+                  crossAxisAlignment: pw.CrossAxisAlignment.start,
+                  children: [
+                    pw.Text(
+                      _strip(q.text),
+                      style: const pw.TextStyle(
+                        fontSize: 10,
+                        color: PdfColors.grey700,
+                      ),
+                    ),
+                    ..._inlineEquationWidgets(q.text, latexImages),
+                    pw.SizedBox(height: 3),
+                    if (correctLabels.isNotEmpty)
+                      ...q.correctAnswers
+                          .where((idx) => idx < q.options.length)
+                          .expand((idx) => [
+                            pw.Text(
+                              '${String.fromCharCode(65 + idx)}. ${_strip(q.options[idx])}',
+                              style: pw.TextStyle(
+                                fontSize: 10,
+                                fontWeight: pw.FontWeight.bold,
+                                color: PdfColors.green800,
+                              ),
+                            ),
+                            ..._inlineEquationWidgets(
+                              q.options[idx],
+                              latexImages,
+                            ),
+                          ])
+                    else if (q.explanation.isNotEmpty) ...[
+                      pw.Text(
+                        _strip(q.explanation),
+                        style: pw.TextStyle(
+                          fontSize: 10,
+                          fontWeight: pw.FontWeight.bold,
+                          color: PdfColors.green800,
+                        ),
+                      ),
+                      ..._inlineEquationWidgets(q.explanation, latexImages),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return widgets;
+  }
+
+  /// Returns image widgets for any inline LaTeX equations found in [text] that
+  /// have a pre-rendered entry in [latexImages]. Equations with no pre-rendered
+  /// image are already shown as plain text via [_strip], so they are skipped.
+  static List<pw.Widget> _inlineEquationWidgets(
+    String text,
+    Map<String, Uint8List> latexImages, {
+    double paddingLeft = 0,
+  }) {
+    final widgets = <pw.Widget>[];
+    final patterns = [
+      RegExp(r'\$\$(.+?)\$\$', dotAll: true),
+      RegExp(r'(?<!\$)\$(?!\$)(.+?)(?<!\$)\$(?!\$)', dotAll: true),
+      RegExp(r'\\\[(.+?)\\\]', dotAll: true),
+      RegExp(r'\\\((.+?)\\\)', dotAll: true),
+    ];
+    final seen = <String>{};
+    for (final pattern in patterns) {
+      for (final match in pattern.allMatches(text)) {
+        final eq = match.group(1)?.trim() ?? '';
+        if (eq.isEmpty || seen.contains(eq)) continue;
+        seen.add(eq);
+        final bytes = latexImages[eq];
+        if (bytes == null) continue;
+        widgets.add(
+          pw.Padding(
+            padding: pw.EdgeInsets.only(left: paddingLeft, top: 4, bottom: 4),
+            child: pw.Center(child: pw.Image(pw.MemoryImage(bytes))),
+          ),
+        );
+      }
+    }
+    return widgets;
+  }
 
   static pw.Widget _buildCoverSection(String title, String? summary) {
     return pw.Center(

--- a/lib/data/services/pdf_export_service.dart
+++ b/lib/data/services/pdf_export_service.dart
@@ -18,6 +18,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:quizdy/data/services/pdf_export_generator.dart';
+import 'package:quizdy/domain/models/quiz/question.dart';
 import 'package:quizdy/domain/models/quiz/study_chunk.dart';
 import 'package:web/web.dart' as web;
 
@@ -39,6 +40,10 @@ class StudyPdfExportService {
     String limitationsLabel = 'Limitations',
     String tableOfContentsLabel = 'Table of Contents',
     Map<String, Uint8List> latexImages = const {},
+    List<Question> questions = const [],
+    bool includeAnswers = false,
+    String questionsPageTitle = 'Questions',
+    String answersLabel = 'Answer',
   }) async {
     final pdfBytes = await StudyPdfGenerator.generate(
       documentTitle: documentTitle,
@@ -48,6 +53,10 @@ class StudyPdfExportService {
       limitationsLabel: limitationsLabel,
       tableOfContentsLabel: tableOfContentsLabel,
       latexImages: latexImages,
+      questions: questions,
+      includeAnswers: includeAnswers,
+      questionsPageTitle: questionsPageTitle,
+      answersLabel: answersLabel,
     );
 
     final blob = web.Blob(

--- a/lib/data/services/pdf_export_service_io.dart
+++ b/lib/data/services/pdf_export_service_io.dart
@@ -21,6 +21,7 @@ import 'package:flutter/material.dart';
 import 'package:platform_detail/platform_detail.dart';
 import 'package:quizdy/data/services/pdf_export_generator.dart';
 import 'package:quizdy/data/services/pdf_viewer_dialog.dart';
+import 'package:quizdy/domain/models/quiz/question.dart';
 import 'package:quizdy/domain/models/quiz/study_chunk.dart';
 
 /// Mobile and desktop implementation of the PDF export service.
@@ -41,6 +42,10 @@ class StudyPdfExportService {
     String limitationsLabel = 'Limitations',
     String tableOfContentsLabel = 'Table of Contents',
     Map<String, Uint8List> latexImages = const {},
+    List<Question> questions = const [],
+    bool includeAnswers = false,
+    String questionsPageTitle = 'Questions',
+    String answersLabel = 'Answer',
   }) async {
     final pdfBytes = await StudyPdfGenerator.generate(
       documentTitle: documentTitle,
@@ -50,6 +55,10 @@ class StudyPdfExportService {
       limitationsLabel: limitationsLabel,
       tableOfContentsLabel: tableOfContentsLabel,
       latexImages: latexImages,
+      questions: questions,
+      includeAnswers: includeAnswers,
+      questionsPageTitle: questionsPageTitle,
+      answersLabel: answersLabel,
     );
 
     if (!context.mounted) return false;

--- a/lib/presentation/screens/dialogs/export_pdf_options_dialog.dart
+++ b/lib/presentation/screens/dialogs/export_pdf_options_dialog.dart
@@ -1,0 +1,258 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+import 'package:quizdy/core/theme/app_theme.dart';
+import 'package:quizdy/core/theme/extensions/confirm_dialog_colors_extension.dart';
+import 'package:quizdy/presentation/widgets/quizdy_button.dart';
+import 'package:quizdy/presentation/widgets/quizdy_switch.dart';
+
+/// Options returned by [ExportPdfOptionsDialog].
+class PdfExportOptions {
+  final bool includeStudy;
+  final bool includeQuestions;
+  final bool includeAnswers;
+
+  const PdfExportOptions({
+    this.includeStudy = true,
+    required this.includeQuestions,
+    required this.includeAnswers,
+  });
+}
+
+/// Dialog that lets the user configure PDF export options before exporting.
+///
+/// When [hasStudy] is `true`, a toggle to include the study content is shown
+/// at the top. When [hasQuestions] is `true`, toggles for a questions page
+/// and optional correct answers are shown below.
+/// Returns a [PdfExportOptions] if the user confirms, or `null` if cancelled.
+class ExportPdfOptionsDialog extends StatefulWidget {
+  /// Whether there is study content available to include.
+  final bool hasStudy;
+
+  /// Whether the quiz file has questions available to include.
+  final bool hasQuestions;
+
+  const ExportPdfOptionsDialog({
+    super.key,
+    required this.hasStudy,
+    required this.hasQuestions,
+  });
+
+  @override
+  State<ExportPdfOptionsDialog> createState() => _ExportPdfOptionsDialogState();
+}
+
+class _ExportPdfOptionsDialogState extends State<ExportPdfOptionsDialog> {
+  bool _includeStudy = true;
+  bool _includeQuestions = false;
+  bool _includeAnswers = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context)!;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final colors = context.appColors;
+    final borderColor = isDark ? Colors.transparent : AppTheme.borderColor;
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 480),
+        width: MediaQuery.of(context).size.width,
+        decoration: BoxDecoration(
+          color: colors.card,
+          borderRadius: BorderRadius.circular(24),
+          border: Border.all(color: borderColor, width: 1),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.1),
+              blurRadius: 20,
+              offset: const Offset(0, 10),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header
+            Padding(
+              padding: const EdgeInsets.fromLTRB(32, 32, 32, 16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Text(
+                      localizations.exportPdfOptionsTitle,
+                      style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.w700,
+                        color: colors.title,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: colors.surface,
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: IconButton(
+                      icon: Icon(
+                        LucideIcons.x,
+                        color: colors.subtitle,
+                        size: 20,
+                      ),
+                      onPressed: () => context.pop(),
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints(),
+                      style: IconButton.styleFrom(
+                        backgroundColor: colors.surface,
+                        shape: const CircleBorder(),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Study toggle
+            if (widget.hasStudy)
+              _ExportOptionRow(
+                title: localizations.exportPdfOptionsIncludeStudy,
+                subtitle: localizations.exportPdfOptionsIncludeStudySubtitle,
+                value: _includeStudy,
+                onChanged: (value) => setState(() => _includeStudy = value),
+                colors: colors,
+              ),
+
+            // Questions / answers toggles
+            if (widget.hasQuestions) ...[
+              _ExportOptionRow(
+                title: localizations.exportPdfOptionsIncludeQuestions,
+                subtitle:
+                    localizations.exportPdfOptionsIncludeQuestionsSubtitle,
+                value: _includeQuestions,
+                onChanged: (value) => setState(() {
+                  _includeQuestions = value;
+                  if (!value) _includeAnswers = false;
+                }),
+                colors: colors,
+              ),
+              if (_includeQuestions)
+                _ExportOptionRow(
+                  title: localizations.exportPdfOptionsIncludeAnswers,
+                  subtitle:
+                      localizations.exportPdfOptionsIncludeAnswersSubtitle,
+                  value: _includeAnswers,
+                  onChanged: (value) => setState(() => _includeAnswers = value),
+                  colors: colors,
+                ),
+            ],
+
+            if (widget.hasStudy || widget.hasQuestions)
+              const SizedBox(height: 8),
+
+            // Actions
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Divider(height: 1, thickness: 1, color: colors.border),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(32, 24, 32, 32),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: QuizdyButton(
+                          expanded: true,
+                          type: QuizdyButtonType.primary,
+                          title: localizations.exportButton,
+                          onPressed: () => context.pop(
+                            PdfExportOptions(
+                              includeStudy: _includeStudy,
+                              includeQuestions: _includeQuestions,
+                              includeAnswers: _includeAnswers,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ExportOptionRow extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final ConfirmingDialogColorsExtension colors;
+
+  const _ExportOptionRow({
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+    required this.colors,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(32, 0, 24, 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: colors.title,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: TextStyle(fontSize: 12, color: colors.subtitle),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          QuizdySwitch(value: value, onChanged: onChanged),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/quiz_loaded_screen.dart
+++ b/lib/presentation/screens/quiz_loaded_screen.dart
@@ -38,6 +38,7 @@ import 'package:quizdy/core/service_locator.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
 import 'package:quizdy/domain/use_cases/check_file_changes_use_case.dart';
 import 'package:quizdy/presentation/blocs/file_bloc/file_bloc.dart';
+import 'package:quizdy/presentation/screens/widgets/study/utils/study_export_pdf_handler.dart';
 import 'package:quizdy/data/repositories/quiz_file_repository.dart';
 import 'package:quizdy/domain/models/custom_exceptions/bad_quiz_file_exception.dart';
 import 'package:quizdy/presentation/blocs/file_bloc/file_event.dart';
@@ -737,6 +738,14 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
                 cachedQuizFile,
               ),
               hasQuestions: cachedQuizFile.questions.isNotEmpty,
+              onExportPdf: () => handleExportPdf(
+                context: context,
+                questions: cachedQuizFile.questions,
+                documentTitle: cachedQuizFile.metadata.title,
+                documentSummary: cachedQuizFile.metadata.description,
+                studyChunks:
+                    cachedQuizFile.study?.content.cache ?? const [],
+              ),
               isPlayEnabled: cachedQuizFile.questions.any((q) => q.isEnabled),
               onPlay: () async {
                 // Filter enabled questions first

--- a/lib/presentation/screens/study_screen.dart
+++ b/lib/presentation/screens/study_screen.dart
@@ -30,8 +30,6 @@ import 'package:quizdy/core/theme/app_theme.dart';
 import 'package:quizdy/data/repositories/quiz_file_repository.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
 import 'package:quizdy/data/services/ai/ai_jit_processing_service.dart';
-import 'package:quizdy/data/services/pdf_export_service_io.dart'
-    if (dart.library.js_interop) 'package:quizdy/data/services/pdf_export_service.dart';
 import 'package:quizdy/domain/models/ai/ai_difficulty_level.dart';
 import 'package:quizdy/domain/models/ai/ai_file_attachment.dart';
 import 'package:quizdy/domain/models/ai/ai_generation_mode.dart';
@@ -54,10 +52,9 @@ import 'package:quizdy/presentation/screens/widgets/request_file_name_dialog.dar
 import 'package:quizdy/presentation/screens/widgets/study/add_edit_chunk_dialog.dart';
 import 'package:quizdy/presentation/screens/widgets/study/study_app_bar.dart';
 import 'package:quizdy/presentation/screens/widgets/study/study_bottom_navigation.dart';
-import 'package:quizdy/domain/models/quiz/study_component.dart';
 import 'package:quizdy/presentation/screens/widgets/study/study_body.dart';
+import 'package:quizdy/presentation/screens/widgets/study/utils/study_export_pdf_handler.dart';
 import 'package:quizdy/presentation/screens/widgets/study/utils/study_quiz_file_helper.dart';
-import 'package:quizdy/presentation/utils/latex_image_renderer.dart';
 
 class StudyScreen extends StatelessWidget {
   final List<StudyChunk> initialChunks;
@@ -229,53 +226,6 @@ class _StudyScreenViewState extends State<StudyScreenView> {
     }
   }
 
-  Future<void> _handleExportPdf() async {
-    final localizations = AppLocalizations.of(context)!;
-    final studyState = context.read<StudyExecutionBloc>().state;
-
-    try {
-      // Collect all formula equations across all ready chunks.
-      final equations = <String>[];
-      for (final chunk in studyState.chunks) {
-        for (final page in chunk.pages) {
-          for (final component in page.uiElements) {
-            if (component.componentType == StudyComponentType.formula) {
-              final eq = component.props['equation']?.toString() ?? '';
-              if (eq.isNotEmpty) equations.add(eq);
-            }
-          }
-        }
-      }
-
-      final latexImages = await LaTeXImageRenderer.renderEquations(
-        context,
-        equations,
-      );
-
-      if (!mounted) return;
-
-      final success = await ServiceLocator.getIt<StudyPdfExportService>()
-          .exportStudy(
-            context: context,
-            documentTitle: studyState.documentTitle,
-            documentSummary: studyState.documentSummary,
-            chunks: studyState.chunks,
-            advantagesLabel: localizations.studyComponentAdvantages,
-            limitationsLabel: localizations.studyComponentLimitations,
-            tableOfContentsLabel: localizations.studyPdfTableOfContents,
-            latexImages: latexImages,
-          );
-
-      if (success == true && mounted) {
-        context.presentSnackBar(localizations.exportPdfSuccess);
-      }
-    } catch (_) {
-      if (mounted) {
-        context.presentSnackBar(localizations.exportPdfError);
-      }
-    }
-  }
-
   Future<void> _handleChunkImport() async {
     try {
       FilePickerResult? result = await FilePicker.pickFiles(
@@ -442,7 +392,10 @@ class _StudyScreenViewState extends State<StudyScreenView> {
           hideStartQuizButton: widget.hideStartQuizButton,
           onSave: _handleSave,
           onImport: _handleChunkImport,
-          onExportPdf: _handleExportPdf,
+          onExportPdf: () => handleExportPdf(
+            context: context,
+            questions: widget.quizFile?.questions ?? const [],
+          ),
           onAddChunk: () async {
             final localizations = AppLocalizations.of(context)!;
             final result = await showDialog<Map<String, String>>(

--- a/lib/presentation/screens/widgets/quiz_loaded_bottom_bar.dart
+++ b/lib/presentation/screens/widgets/quiz_loaded_bottom_bar.dart
@@ -28,6 +28,7 @@ class QuizLoadedBottomBar extends StatefulWidget {
   final VoidCallback onSave;
   final VoidCallback onDelete;
   final VoidCallback onPlay;
+  final VoidCallback? onExportPdf;
   final bool isPlayEnabled;
   final int selectedQuestionCount;
   final bool showSaveButton;
@@ -45,6 +46,7 @@ class QuizLoadedBottomBar extends StatefulWidget {
     required this.onDelete,
     required this.onPlay,
     required this.onDeleteDuplicates,
+    this.onExportPdf,
     this.isPlayEnabled = false,
     this.selectedQuestionCount = 0,
     this.showSaveButton = false,
@@ -218,6 +220,17 @@ class _QuizLoadedBottomBarState extends State<QuizLoadedBottomBar> {
                       ),
                       flex: 2,
                     ),
+                    if (widget.hasQuestions)
+                      (
+                        button: QuizdyButton(
+                          type: QuizdyButtonType.secondary,
+                          icon: LucideIcons.fileDown,
+                          expanded: true,
+                          title: localizations.exportAsPdf,
+                          onPressed: widget.onExportPdf,
+                        ),
+                        flex: 2,
+                      ),
                   ];
 
                   final buttonCount = buttonData.length;

--- a/lib/presentation/screens/widgets/study/study_bottom_navigation.dart
+++ b/lib/presentation/screens/widgets/study/study_bottom_navigation.dart
@@ -83,10 +83,19 @@ class StudyBottomNavigation extends StatelessWidget {
                         currentQuizFile,
                       );
 
+                  final hasReadyChunks = state.chunks.any(
+                    (c) =>
+                        c.status == StudyChunkState.completed ||
+                        c.status == StudyChunkState.downloaded,
+                  );
+                  final hasQuestions =
+                      currentQuizFile.questions.isNotEmpty;
+
                   return StudyIndexFooterWidget(
                     localizations: localizations,
                     progressPercentage: state.progressPercentage,
                     hasChunks: state.chunks.isNotEmpty,
+                    canExportPdf: hasReadyChunks || hasQuestions,
                     selectedChunkCount: state.selectedIndices.length,
                     hasDuplicates: state.hasDuplicates,
                     isStartQuizEnabled:

--- a/lib/presentation/screens/widgets/study/study_index_footer_widget.dart
+++ b/lib/presentation/screens/widgets/study/study_index_footer_widget.dart
@@ -39,6 +39,7 @@ class StudyIndexFooterWidget extends StatefulWidget {
   final bool hasDuplicates;
   final bool showSaveButton;
   final bool hasChunks;
+  final bool canExportPdf;
 
   const StudyIndexFooterWidget({
     super.key,
@@ -57,6 +58,7 @@ class StudyIndexFooterWidget extends StatefulWidget {
     this.hasDuplicates = false,
     this.showSaveButton = true,
     this.hasChunks = true,
+    this.canExportPdf = false,
   });
 
   @override
@@ -229,7 +231,7 @@ class _StudyIndexFooterWidgetState extends State<StudyIndexFooterWidget> {
                       ),
                       flex: 2,
                     ),
-                    if (widget.hasChunks)
+                    if (widget.canExportPdf)
                       (
                         button: QuizdyButton(
                           type: QuizdyButtonType.secondary,

--- a/lib/presentation/screens/widgets/study/utils/study_export_pdf_handler.dart
+++ b/lib/presentation/screens/widgets/study/utils/study_export_pdf_handler.dart
@@ -1,0 +1,186 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:quizdy/core/context_extension.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+import 'package:quizdy/core/service_locator.dart';
+import 'package:quizdy/data/services/pdf_export_service_io.dart'
+    if (dart.library.js_interop) 'package:quizdy/data/services/pdf_export_service.dart';
+import 'package:quizdy/domain/models/quiz/question.dart';
+import 'package:quizdy/domain/models/quiz/study_chunk.dart';
+import 'package:quizdy/domain/models/quiz/study_component.dart';
+import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_bloc.dart';
+import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_state.dart';
+import 'package:quizdy/presentation/screens/dialogs/export_pdf_options_dialog.dart';
+import 'package:quizdy/presentation/utils/latex_image_renderer.dart';
+
+/// Exports a PDF, optionally showing a dialog to configure question/answer pages.
+///
+/// Behaviour:
+/// - No questions → skips the dialog and exports the study content directly.
+/// - Has questions but no study chunks → shows the dialog and exports only the
+///   selected question/answer pages (no study content).
+/// - Has both → shows the dialog and exports study content plus the selected
+///   question/answer pages.
+///
+/// [questions] are the quiz questions available for inclusion in the PDF.
+/// [documentTitle], [documentSummary] and [studyChunks] can be supplied
+/// directly (e.g. from the quiz-loaded screen where no [StudyExecutionBloc]
+/// is present). When omitted they are read from [StudyExecutionBloc].
+Future<void> handleExportPdf({
+  required BuildContext context,
+  List<Question> questions = const [],
+  String? documentTitle,
+  String? documentSummary,
+  List<StudyChunk>? studyChunks,
+}) async {
+  final localizations = AppLocalizations.of(context)!;
+
+  final StudyExecutionState? studyState = studyChunks == null
+      ? context.read<StudyExecutionBloc>().state
+      : null;
+
+  final String title =
+      documentTitle ?? studyState?.documentTitle ?? '';
+  final String? summary =
+      documentSummary ?? studyState?.documentSummary;
+  final List<StudyChunk> chunks = studyChunks ?? studyState?.chunks ?? const [];
+
+  final hasStudy = chunks.isNotEmpty;
+  final hasQuestions = questions.isNotEmpty;
+
+  PdfExportOptions options;
+
+  if (!hasQuestions) {
+    // No questions: export study directly without showing the dialog.
+    options = const PdfExportOptions(
+      includeStudy: true,
+      includeQuestions: false,
+      includeAnswers: false,
+    );
+  } else {
+    // Has questions: let the user choose what to include.
+    final result = await showDialog<PdfExportOptions>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => ExportPdfOptionsDialog(
+        hasStudy: hasStudy,
+        hasQuestions: true,
+      ),
+    );
+    if (result == null || !context.mounted) return;
+    options = result;
+  }
+
+  final exportQuestions =
+      options.includeQuestions ? questions : const <Question>[];
+  final exportChunks =
+      (hasStudy && options.includeStudy) ? chunks : const <StudyChunk>[];
+
+  try {
+    final equations = _collectEquations(chunks, exportQuestions);
+
+    final latexImages = await LaTeXImageRenderer.renderEquations(
+      context,
+      equations,
+    );
+
+    if (!context.mounted) return;
+
+    final success = await ServiceLocator.getIt<StudyPdfExportService>()
+        .exportStudy(
+          context: context,
+          documentTitle: title,
+          documentSummary: summary,
+          chunks: exportChunks,
+          advantagesLabel: localizations.studyComponentAdvantages,
+          limitationsLabel: localizations.studyComponentLimitations,
+          tableOfContentsLabel: localizations.studyPdfTableOfContents,
+          latexImages: latexImages,
+          questions: exportQuestions,
+          includeAnswers: options.includeAnswers,
+          questionsPageTitle: localizations.exportPdfQuestionsPageTitle,
+          answersLabel: localizations.exportPdfAnswersLabel,
+        );
+
+    if (success == true && context.mounted) {
+      context.presentSnackBar(localizations.exportPdfSuccess);
+    }
+  } catch (_) {
+    if (context.mounted) {
+      context.presentSnackBar(localizations.exportPdfError);
+    }
+  }
+}
+
+List<String> _collectEquations(
+  List<StudyChunk> chunks,
+  List<Question> questions,
+) {
+  final seen = <String>{};
+
+  void addEquation(String eq) {
+    if (eq.isNotEmpty) seen.add(eq);
+  }
+
+  // Equations from study chunk formula components.
+  for (final chunk in chunks) {
+    for (final page in chunk.pages) {
+      for (final component in page.uiElements) {
+        if (component.componentType == StudyComponentType.formula) {
+          addEquation(component.props['equation']?.toString() ?? '');
+        }
+      }
+    }
+  }
+
+  // Inline equations embedded in question texts, options and explanations.
+  for (final q in questions) {
+    for (final eq in _extractInlineEquations(q.text)) {
+      addEquation(eq);
+    }
+    for (final option in q.options) {
+      for (final eq in _extractInlineEquations(option)) {
+        addEquation(eq);
+      }
+    }
+    for (final eq in _extractInlineEquations(q.explanation)) {
+      addEquation(eq);
+    }
+  }
+
+  return seen.toList();
+}
+
+/// Extracts raw equation strings (without delimiters) from a text that may
+/// contain inline or display LaTeX math.
+List<String> _extractInlineEquations(String text) {
+  final equations = <String>[];
+  final patterns = [
+    RegExp(r'\$\$(.+?)\$\$', dotAll: true),
+    RegExp(r'(?<!\$)\$(?!\$)(.+?)(?<!\$)\$(?!\$)', dotAll: true),
+    RegExp(r'\\\[(.+?)\\\]', dotAll: true),
+    RegExp(r'\\\((.+?)\\\)', dotAll: true),
+  ];
+  for (final pattern in patterns) {
+    for (final match in pattern.allMatches(text)) {
+      final eq = match.group(1)?.trim() ?? '';
+      if (eq.isNotEmpty) equations.add(eq);
+    }
+  }
+  return equations;
+}


### PR DESCRIPTION
## Summary

  - Added an **Export as PDF options dialog** with three configurable switches: include study content, include a questions page, and include a separate answers page.
  - The export button is **only shown when exportable content exists** (ready study chunks or questions).
  - Dialog is **skipped** when there are no questions — study is exported directly.
  - Questions and answers sections are **registered in the PDF table of contents**.
  - **LaTeX equations** in question texts, options, and explanations are pre-rendered as images in the PDF.
  - Export action also available from the **Quiz Editor bottom bar**, reading study chunks from the associated quiz file when present.
  - Extracted export logic into a reusable `handleExportPdf` function, independent of `StudyExecutionBloc`.