### PR TITLE
fix(study): change initial action button from Edit to Create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: Implemented `CardStatusBar` and applied for `StudyIndexChunkCard` and `QuestionPreviewCard`.
 - feat(pdf): add export options dialog with questions, answers and study toggles.
+- ux(study): Updated the initial Study Mode action button from `Edit` to `Create` and replaced the pencil icon with an add icon.
 
 ## [1.12.0] - 2026-04-17
 

--- a/lib/presentation/screens/widgets/study/study_index_chunk_card.dart
+++ b/lib/presentation/screens/widgets/study/study_index_chunk_card.dart
@@ -323,13 +323,13 @@ class _StudyIndexChunkCardState extends State<StudyIndexChunkCard> {
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             const Icon(
-                              Icons.edit_outlined,
+                              Icons.add_outlined,
                               size: 12,
                               color: AppTheme.secondaryColor,
                             ),
                             const SizedBox(width: 4),
                             Text(
-                              localizations.edit,
+                              localizations.create,
                               style: const TextStyle(
                                 fontSize: 11,
                                 fontWeight: FontWeight.w600,

--- a/lib/presentation/screens/widgets/study/study_sections_sidebar.dart
+++ b/lib/presentation/screens/widgets/study/study_sections_sidebar.dart
@@ -460,13 +460,13 @@ class _SidebarChunkItem extends StatelessWidget {
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             const Icon(
-                              Icons.edit_outlined,
+                              Icons.add_outlined,
                               size: 13,
                               color: AppTheme.secondaryColor,
                             ),
                             const SizedBox(width: 5),
                             Text(
-                              localizations.edit,
+                              localizations.create,
                               style: const TextStyle(
                                 fontSize: 11,
                                 fontWeight: FontWeight.w600,


### PR DESCRIPTION
## Summary
- change the initial Study Mode action button label from Edit to Create
- replace the action icon from pencil to add icon in both index card and sidebar
- add changelog entry under version 1.13.0

Closes #376