### PR TITLE
fix(quiz): move missing explanation warning to dedicated line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: Implemented `CardStatusBar` and applied for `StudyIndexChunkCard` and `QuestionPreviewCard`.
 - feat(pdf): add export options dialog with questions, answers and study toggles.
+- ux(quiz): Moved the missing explanation warning in question cards to its own line and added explanatory text in Quiz Preview.
 
 ## [1.12.0] - 2026-04-17
 

--- a/lib/presentation/screens/widgets/question_preview_card.dart
+++ b/lib/presentation/screens/widgets/question_preview_card.dart
@@ -218,20 +218,6 @@ class _QuestionPreviewCardState extends State<QuestionPreviewCard> {
                                     ),
                                   ),
                                 ),
-
-                                if (widget.question.explanation.isEmpty) ...[
-                                  const SizedBox(width: 8),
-                                  Tooltip(
-                                    message: AppLocalizations.of(
-                                      context,
-                                    )!.missingExplanationTooltip,
-                                    child: Icon(
-                                      LucideIcons.alertTriangle,
-                                      size: 14,
-                                      color: customColors.warning,
-                                    ),
-                                  ),
-                                ],
                               ],
                             ),
                           ),
@@ -331,6 +317,33 @@ class _QuestionPreviewCardState extends State<QuestionPreviewCard> {
                         ],
                       ),
                     ),
+
+                    if (widget.question.explanation.isEmpty)
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(20, 0, 20, 10),
+                        child: Row(
+                          children: [
+                            Icon(
+                              LucideIcons.alertTriangle,
+                              size: 14,
+                              color: customColors.warning,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                AppLocalizations.of(
+                                  context,
+                                )!.missingExplanationTooltip,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w500,
+                                  color: customColors.warning,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
 
                     // Question Text Preview (Always visible)
                     Padding(


### PR DESCRIPTION
## Summary
- move the missing explanation warning out of the question header row in Quiz Preview
- place the warning in its own dedicated line so it is no longer adjacent to action buttons
- show explanatory warning text using existing localized message
- add changelog entry under version 1.13.0

Closes #378