### PR TITLE
fix(quiz): swap start button hierarchy in quiz count dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: Implemented `CardStatusBar` and applied for `StudyIndexChunkCard` and `QuestionPreviewCard`.
 - feat(pdf): add export options dialog with questions, answers and study toggles.
+- ux(quiz): Updated the quiz start dialog so the selected-questions action is primary and the generic start action is secondary.
 - ux(quiz): Moved the missing explanation warning in question cards to its own line and added explanatory text in Quiz Preview.
 - ux(study): Updated the initial Study Mode action button from `Edit` to `Create` and replaced the pencil icon with an add icon.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: Implemented `CardStatusBar` and applied for `StudyIndexChunkCard` and `QuestionPreviewCard`.
 - feat(pdf): add export options dialog with questions, answers and study toggles.
-- ux(quiz): Updated the quiz start dialog so the selected-questions action is primary and the generic start action is secondary.
+- ux(quiz): Updated the quiz start dialog so the selected-questions action is primary, and the generic start action becomes secondary only when selections are available.
 - ux(quiz): Moved the missing explanation warning in question cards to its own line and added explanatory text in Quiz Preview.
 - ux(study): Updated the initial Study Mode action button from `Edit` to `Create` and replaced the pencil icon with an add icon.
 

--- a/lib/presentation/screens/dialogs/question_count_selection_dialog.dart
+++ b/lib/presentation/screens/dialogs/question_count_selection_dialog.dart
@@ -724,7 +724,7 @@ class _QuestionCountSelectionDialogState
                       // Start with selected questions button
                       if (widget.selectedQuestionCount > 0) ...[
                         QuizdyButton(
-                          type: QuizdyButtonType.secondary,
+                          type: QuizdyButtonType.primary,
                           title: l10n.startWithSelectedQuestions(
                             widget.selectedQuestionCount,
                           ),
@@ -744,6 +744,7 @@ class _QuestionCountSelectionDialogState
                       QuizdyButton(
                         title: AppLocalizations.of(context)!.startQuiz,
                         icon: LucideIcons.play,
+                        type: QuizdyButtonType.secondary,
                         expanded: true,
                         onPressed:
                             ((_examTimeEnabled && _hasExamTimeError) ||

--- a/lib/presentation/screens/dialogs/question_count_selection_dialog.dart
+++ b/lib/presentation/screens/dialogs/question_count_selection_dialog.dart
@@ -744,7 +744,9 @@ class _QuestionCountSelectionDialogState
                       QuizdyButton(
                         title: AppLocalizations.of(context)!.startQuiz,
                         icon: LucideIcons.play,
-                        type: QuizdyButtonType.secondary,
+                        type: widget.selectedQuestionCount > 0
+                            ? QuizdyButtonType.secondary
+                            : QuizdyButtonType.primary,
                         expanded: true,
                         onPressed:
                             ((_examTimeEnabled && _hasExamTimeError) ||


### PR DESCRIPTION
## Summary
- make the selected-questions start action primary
- make the generic Start Quiz action secondary in the question count dialog
- add changelog entry under version 1.13.0

Closes #380