### PR TITLE
fix: AI Assistant button in question cards now updates instantly when the API key is added or removed in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ux(quiz): Updated the quiz start dialog so the selected-questions action is primary, and the generic start action becomes secondary only when selections are available.
 - ux(quiz): Moved the missing explanation warning in question cards to its own line and added explanatory text in Quiz Preview.
 - ux(study): Updated the initial Study Mode action button from `Edit` to `Create` and replaced the pencil icon with an add icon.
+- fix: AI Assistant button in question cards now updates instantly when the API key is added or removed in Settings.
 
 ## [1.12.0] - 2026-04-17
 

--- a/lib/data/services/configuration_service.dart
+++ b/lib/data/services/configuration_service.dart
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:quizdy/domain/models/quiz/question_order.dart';
 import 'package:quizdy/domain/models/ai/ai_generation_stored_settings.dart';
@@ -70,7 +71,13 @@ class ConfigurationService {
 
   final SharedPreferences sharedPreferences;
 
+  final ValueNotifier<bool> aiAvailabilityNotifier = ValueNotifier(false);
+
   ConfigurationService({required this.sharedPreferences});
+
+  Future<void> _refreshAiAvailability() async {
+    aiAvailabilityNotifier.value = await getIsAiAvailable();
+  }
 
   /// Gets whether onboarding has been completed
   Future<bool> getOnboardingCompleted() async {
@@ -142,6 +149,7 @@ class ConfigurationService {
   Future<void> saveAIAssistantEnabled(bool enabled) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_aiAssistantEnabledKey, enabled);
+    await _refreshAiAvailability();
   }
 
   /// Gets whether AI assistant is enabled, defaults to true
@@ -155,6 +163,7 @@ class ConfigurationService {
     final prefs = await SharedPreferences.getInstance();
     final encryptedApiKey = EncryptionService.encrypt(apiKey);
     await prefs.setString(_openaiApiKeyKey, encryptedApiKey);
+    await _refreshAiAvailability();
   }
 
   /// Gets OpenAI API Key (decrypted)
@@ -173,6 +182,7 @@ class ConfigurationService {
   Future<void> deleteOpenAIApiKey() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_openaiApiKeyKey);
+    await _refreshAiAvailability();
   }
 
   /// Saves Gemini API Key securely (encrypted)
@@ -180,6 +190,7 @@ class ConfigurationService {
     final prefs = await SharedPreferences.getInstance();
     final encryptedApiKey = EncryptionService.encrypt(apiKey);
     await prefs.setString(_geminiApiKeyKey, encryptedApiKey);
+    await _refreshAiAvailability();
   }
 
   /// Gets Gemini API Key (decrypted)
@@ -198,6 +209,7 @@ class ConfigurationService {
   Future<void> deleteGeminiApiKey() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_geminiApiKeyKey);
+    await _refreshAiAvailability();
   }
 
   /// Saves whether answers should be randomized

--- a/lib/presentation/screens/widgets/question_list_widget.dart
+++ b/lib/presentation/screens/widgets/question_list_widget.dart
@@ -53,19 +53,35 @@ class QuestionListWidget extends StatefulWidget {
 }
 
 class _QuestionListWidgetState extends State<QuestionListWidget> {
-  bool _aiAssistantEnabled = true;
+  bool _aiAssistantEnabled = false;
+  late final ConfigurationService _configService;
 
   @override
   void initState() {
     super.initState();
+    _configService = ServiceLocator.getIt<ConfigurationService>();
+    _configService.aiAvailabilityNotifier.addListener(_onAiAvailabilityChanged);
     _loadAISettings();
   }
 
-  Future<void> _loadAISettings() async {
-    final aiEnabled = await ServiceLocator.getIt<ConfigurationService>()
-        .getIsAiAvailable();
+  @override
+  void dispose() {
+    _configService.aiAvailabilityNotifier.removeListener(
+      _onAiAvailabilityChanged,
+    );
+    super.dispose();
+  }
+
+  void _onAiAvailabilityChanged() {
     setState(() {
-      _aiAssistantEnabled = aiEnabled;
+      _aiAssistantEnabled = _configService.aiAvailabilityNotifier.value;
+    });
+  }
+
+  Future<void> _loadAISettings() async {
+    await _configService.getIsAiAvailable().then((aiEnabled) {
+      if (!mounted) return;
+      _configService.aiAvailabilityNotifier.value = aiEnabled;
     });
   }
 
@@ -211,13 +227,6 @@ class _QuestionListWidgetState extends State<QuestionListWidget> {
       }
     }
     widget.onSelectionChanged?.call(newSelection);
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // Recargar configuración cuando el widget se actualiza
-    _loadAISettings();
   }
 
   Widget _buildQuestionCard(


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                                     
  - Added `ValueNotifier<bool> aiAvailabilityNotifier` to `ConfigurationService` (singleton) that fires whenever AI availability changes.                                                                                            
  - `ConfigurationService` now refreshes the notifier after every API key save/delete and `saveAIAssistantEnabled` call.                                                                                                             
  - `QuestionListWidget` subscribes to the notifier in `initState` and updates the AI button visibility reactively, replacing the previous polling via `didChangeDependencies`. 
  - Fixes: https://github.com/vicajilau/quizdy/issues/386