### PR TITLE
feat(study): Added Edit and Delete action buttons to study section cards, with hover reveal on desktop, expandable toggle on mobile, and direct delete shortcut when no edit action is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ux(quiz): Moved the missing explanation warning in question cards to its own line and added explanatory text in Quiz Preview.
 - ux(study): Updated the initial Study Mode action button from `Edit` to `Create` and replaced the pencil icon with an add icon.
 - fix: AI Assistant button in question cards now updates instantly when the API key is added or removed in Settings.
+- ux(study): Added Edit and Delete action buttons to study section cards, with hover reveal on desktop, expandable toggle on mobile, and direct delete shortcut when no edit action is available.
 
 ## [1.12.0] - 2026-04-17
 

--- a/lib/presentation/blocs/study_execution_bloc/study_execution_bloc.dart
+++ b/lib/presentation/blocs/study_execution_bloc/study_execution_bloc.dart
@@ -92,6 +92,7 @@ class StudyExecutionBloc
     on<ClearSelectionRequested>(_onClearSelectionRequested);
     on<DownloadStudyChunkRequested>(_onDownloadStudyChunkRequested);
     on<GenerateAiStudyChunksRequested>(_onGenerateAiStudyChunksRequested);
+    on<DeleteChunkAtIndexRequested>(_onDeleteChunkAtIndexRequested);
     on<DeleteSelectedChunksRequested>(_onDeleteSelectedChunksRequested);
     on<DeleteDuplicateChunksRequested>(_onDeleteDuplicateChunksRequested);
     on<ImportStudyChunksRequested>(_onImportStudyChunksRequested);
@@ -634,6 +635,47 @@ class StudyExecutionBloc
     } catch (e) {
       emit(state.copyWith(isLoading: false, error: e.toString()));
     }
+  }
+
+  void _onDeleteChunkAtIndexRequested(
+    DeleteChunkAtIndexRequested event,
+    Emitter<StudyExecutionState> emit,
+  ) {
+    final updatedChunks = List<StudyChunk>.from(state.chunks);
+    updatedChunks.removeAt(event.chunkIndex);
+
+    for (int i = 0; i < updatedChunks.length; i++) {
+      updatedChunks[i] = updatedChunks[i].copyWith(chunkIndex: i);
+    }
+
+    int newCurrentIndex = state.currentChunkIndex;
+    if (updatedChunks.isEmpty) {
+      newCurrentIndex = 0;
+    } else if (newCurrentIndex >= updatedChunks.length) {
+      newCurrentIndex = updatedChunks.length - 1;
+    }
+
+    final updatedSelection = state.selectedIndices
+        .where((i) => i != event.chunkIndex)
+        .map((i) => i > event.chunkIndex ? i - 1 : i)
+        .toSet();
+
+    final newState = _updateProgress(
+      state.copyWith(
+        chunks: updatedChunks,
+        currentChunkIndex: newCurrentIndex,
+        selectedIndices: updatedSelection,
+      ),
+    );
+    emit(newState);
+
+    onProgressChanged?.call(
+      newState.progressPercentage,
+      newState.processedChunks,
+      newState.chunks,
+      newState.fileUri,
+      newState.fileExpirationTime,
+    );
   }
 
   void _onDeleteSelectedChunksRequested(

--- a/lib/presentation/blocs/study_execution_bloc/study_execution_event.dart
+++ b/lib/presentation/blocs/study_execution_bloc/study_execution_event.dart
@@ -99,6 +99,13 @@ class DeleteDuplicateChunksRequested extends StudyExecutionEvent {
   const DeleteDuplicateChunksRequested();
 }
 
+/// Dispatched to delete a single chunk at the given index.
+class DeleteChunkAtIndexRequested extends StudyExecutionEvent {
+  final int chunkIndex;
+
+  const DeleteChunkAtIndexRequested(this.chunkIndex);
+}
+
 /// Dispatched to download (JIT-process) a chunk from the index view without navigating away.
 class DownloadStudyChunkRequested extends StudyExecutionEvent {
   final int chunkIndex;

--- a/lib/presentation/screens/quiz_execution/quiz_in_progress_view.dart
+++ b/lib/presentation/screens/quiz_execution/quiz_in_progress_view.dart
@@ -280,29 +280,7 @@ class _QuizInProgressViewState extends State<QuizInProgressView>
                           const SizedBox(width: 8),
                         ],
 
-                        IconButton(
-                          onPressed: () => BackPressHandler.handle(
-                            context,
-                            context.read<QuizExecutionBloc>(),
-                          ),
-                          style: IconButton.styleFrom(
-                            backgroundColor: colors.card,
-                            fixedSize: const Size(48, 48),
-                            padding: EdgeInsets.zero,
-                            shape: CircleBorder(
-                              side: closeBtnBorder == Colors.transparent
-                                  ? BorderSide.none
-                                  : BorderSide(color: closeBtnBorder),
-                            ),
-                          ),
-                          icon: Icon(
-                            Icons.close,
-                            color: colors.subtitle,
-                            size: 24,
-                          ),
-                        ),
                         if (isStudyMode && !_isChatOpen) ...[
-                          const SizedBox(width: 8),
                           IconButton(
                             onPressed: _isAiAvailable
                                 ? openAiChat
@@ -328,6 +306,31 @@ class _QuizInProgressViewState extends State<QuizInProgressView>
                             ),
                           ),
                         ],
+
+                        Padding(
+                          padding: const EdgeInsets.only(left: 8.0),
+                          child: IconButton(
+                            onPressed: () => BackPressHandler.handle(
+                              context,
+                              context.read<QuizExecutionBloc>(),
+                            ),
+                            style: IconButton.styleFrom(
+                              backgroundColor: colors.card,
+                              fixedSize: const Size(48, 48),
+                              padding: EdgeInsets.zero,
+                              shape: CircleBorder(
+                                side: closeBtnBorder == Colors.transparent
+                                    ? BorderSide.none
+                                    : BorderSide(color: closeBtnBorder),
+                              ),
+                            ),
+                            icon: Icon(
+                              Icons.close,
+                              color: colors.subtitle,
+                              size: 24,
+                            ),
+                          ),
+                        ),
                       ],
                     ),
                   ],

--- a/lib/presentation/screens/widgets/question_list_widget.dart
+++ b/lib/presentation/screens/widgets/question_list_widget.dart
@@ -60,6 +60,7 @@ class _QuestionListWidgetState extends State<QuestionListWidget> {
   void initState() {
     super.initState();
     _configService = ServiceLocator.getIt<ConfigurationService>();
+    _aiAssistantEnabled = _configService.aiAvailabilityNotifier.value;
     _configService.aiAvailabilityNotifier.addListener(_onAiAvailabilityChanged);
     _loadAISettings();
   }
@@ -97,10 +98,9 @@ class _QuestionListWidgetState extends State<QuestionListWidget> {
 
     return ReorderableListView.builder(
       onReorder: _onReorder,
-      padding: const EdgeInsets.symmetric(horizontal: 4.0).copyWith(
-        top: 24,
-        bottom: 100,
-      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: 4.0,
+      ).copyWith(top: 24, bottom: 100),
       itemCount: widget.quizFile.questions.length,
       buildDefaultDragHandles: false, // We use custom drag handles
       itemBuilder: (constext, index) {
@@ -111,7 +111,9 @@ class _QuestionListWidgetState extends State<QuestionListWidget> {
         return AnimatedBuilder(
           animation: animation,
           builder: (context, child) {
-            final double animValue = Curves.easeInOut.transform(animation.value);
+            final double animValue = Curves.easeInOut.transform(
+              animation.value,
+            );
             final double elevation = lerpDouble(0, 8, animValue)!;
             final double scale = lerpDouble(1, 1.02, animValue)!;
 

--- a/lib/presentation/screens/widgets/question_preview_card.dart
+++ b/lib/presentation/screens/widgets/question_preview_card.dart
@@ -289,7 +289,7 @@ class _QuestionPreviewCardState extends State<QuestionPreviewCard> {
                                   _buildIconButton(
                                     icon: _isActionsExpanded
                                         ? LucideIcons.chevronRight
-                                        : LucideIcons.chevronLeft,
+                                        : Icons.more_horiz,
                                     color: Theme.of(context).hintColor,
                                     onPressed: () {
                                       setState(() {

--- a/lib/presentation/screens/widgets/study/study_index_chunk_card.dart
+++ b/lib/presentation/screens/widgets/study/study_index_chunk_card.dart
@@ -415,54 +415,74 @@ class _StudyIndexChunkCardState extends State<StudyIndexChunkCard> {
           Positioned(
             top: 10,
             right: 10,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                AnimatedSize(
-                  duration: Durations.medium2,
-                  curve: Curves.easeInOutCubic,
-                  child:
-                      ((!isMobile && _isHovered) ||
-                          (isMobile && _isActionsExpanded))
-                      ? Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            if (widget.onEdit != null &&
-                                hasContent &&
-                                chunk.aiSummary != null &&
-                                chunk.aiSummary!.isNotEmpty) ...[
-                              _buildIconButton(
-                                icon: LucideIcons.pencil,
-                                color: AppTheme.secondaryColor,
-                                onPressed: widget.onEdit!,
-                                tooltip: localizations.edit,
-                              ),
-                              const SizedBox(width: 4),
-                            ],
-                            if (widget.onDelete != null) ...[
-                              _buildIconButton(
-                                icon: LucideIcons.trash2,
-                                color: theme.colorScheme.error,
-                                onPressed: widget.onDelete!,
-                                tooltip: localizations.deleteButton,
-                              ),
-                              const SizedBox(width: 4),
-                            ],
-                          ],
-                        )
-                      : const SizedBox.shrink(),
-                ),
-                if (isMobile)
-                  _buildIconButton(
-                    icon: _isActionsExpanded
-                        ? LucideIcons.chevronRight
-                        : Icons.more_horiz,
-                    color: Theme.of(context).hintColor,
-                    onPressed: () => setState(
-                      () => _isActionsExpanded = !_isActionsExpanded,
+            child: Builder(
+              builder: (context) {
+                final hasEditAction =
+                    widget.onEdit != null &&
+                    hasContent &&
+                    chunk.aiSummary != null &&
+                    chunk.aiSummary!.isNotEmpty;
+                final hasDeleteAction = widget.onDelete != null;
+                // On mobile with only one action, show it directly (no toggle)
+                final showDirectOnMobile =
+                    isMobile && !hasEditAction && hasDeleteAction;
+
+                if (showDirectOnMobile) {
+                  return _buildIconButton(
+                    icon: LucideIcons.trash2,
+                    color: theme.colorScheme.error,
+                    onPressed: widget.onDelete!,
+                    tooltip: localizations.deleteButton,
+                  );
+                }
+
+                return Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    AnimatedSize(
+                      duration: Durations.medium2,
+                      curve: Curves.easeInOutCubic,
+                      child:
+                          ((!isMobile && _isHovered) ||
+                              (isMobile && _isActionsExpanded))
+                          ? Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                if (hasEditAction) ...[
+                                  _buildIconButton(
+                                    icon: LucideIcons.pencil,
+                                    color: AppTheme.secondaryColor,
+                                    onPressed: widget.onEdit!,
+                                    tooltip: localizations.edit,
+                                  ),
+                                  const SizedBox(width: 4),
+                                ],
+                                if (hasDeleteAction) ...[
+                                  _buildIconButton(
+                                    icon: LucideIcons.trash2,
+                                    color: theme.colorScheme.error,
+                                    onPressed: widget.onDelete!,
+                                    tooltip: localizations.deleteButton,
+                                  ),
+                                  const SizedBox(width: 4),
+                                ],
+                              ],
+                            )
+                          : const SizedBox.shrink(),
                     ),
-                  ),
-              ],
+                    if (isMobile)
+                      _buildIconButton(
+                        icon: _isActionsExpanded
+                            ? LucideIcons.chevronRight
+                            : Icons.more_horiz,
+                        color: Theme.of(context).hintColor,
+                        onPressed: () => setState(
+                          () => _isActionsExpanded = !_isActionsExpanded,
+                        ),
+                      ),
+                  ],
+                );
+              },
             ),
           ),
         ],

--- a/lib/presentation/screens/widgets/study/study_index_chunk_card.dart
+++ b/lib/presentation/screens/widgets/study/study_index_chunk_card.dart
@@ -15,6 +15,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:lucide_icons/lucide_icons.dart';
+import 'package:quizdy/core/context_extension.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/core/theme/app_theme.dart';
 import 'package:quizdy/domain/models/quiz/study_chunk.dart';
@@ -30,6 +31,7 @@ class StudyIndexChunkCard extends StatefulWidget {
   final VoidCallback onTap;
   final VoidCallback? onDownload;
   final VoidCallback? onEdit;
+  final VoidCallback? onDelete;
   final VoidCallback? onLongPress;
   final bool isSelected;
   final bool isSelectionMode;
@@ -47,6 +49,7 @@ class StudyIndexChunkCard extends StatefulWidget {
     required this.onTap,
     this.onDownload,
     this.onEdit,
+    this.onDelete,
     this.onLongPress,
     this.isSelected = false,
     this.isSelectionMode = false,
@@ -63,6 +66,9 @@ class StudyIndexChunkCard extends StatefulWidget {
 class _StudyIndexChunkCardState extends State<StudyIndexChunkCard> {
   bool _expanded = false;
   bool _exceedsMaxLines = false;
+  bool _isActionsExpanded = false;
+  bool _isHovered = false;
+
   @override
   Widget build(BuildContext context) {
     final chunk = widget.chunk;
@@ -74,6 +80,7 @@ class _StudyIndexChunkCardState extends State<StudyIndexChunkCard> {
     final isSelected = widget.isSelected;
     final isSelectionMode = widget.isSelectionMode;
 
+    final isMobile = context.isMobile;
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
     final isCompleted = chunk.status == StudyChunkState.completed;
@@ -113,271 +120,354 @@ class _StudyIndexChunkCardState extends State<StudyIndexChunkCard> {
                         ? Border.all(color: Colors.transparent, width: 1)
                         : Border.all(color: AppTheme.borderColor, width: 1))),
       ),
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+
+      child: Row(
         children: [
-          Row(
-            children: [
-              if (isSelectionMode)
-                Padding(
-                  padding: const EdgeInsets.only(right: 12),
-                  child: Container(
-                    width: 24,
-                    height: 24,
-                    decoration: BoxDecoration(
-                      color: isSelected
-                          ? AppTheme.primaryColor
-                          : Colors.transparent,
-                      shape: BoxShape.circle,
-                      border: Border.all(
-                        color: isSelected ? AppTheme.primaryColor : arrowColor,
-                      ),
-                    ),
-                    child: isSelected
-                        ? const Icon(
-                            LucideIcons.check,
-                            size: 16,
-                            color: Colors.white,
-                          )
-                        : null,
-                  ),
-                )
-              else
-                Container(
-                  width: 28,
-                  height: 28,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(14),
-                    color: isCompleted ? AppTheme.primaryColor : pendingBadgeBg,
-                  ),
-                  alignment: Alignment.center,
-                  child: Text(
-                    '${index + 1}',
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                      color: isCompleted ? Colors.white : pendingBadgeText,
-                    ),
-                  ),
-                ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Flexible(
-                          child: Text(
-                            chunk.title,
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: isCompleted
-                                  ? FontWeight.w600
-                                  : FontWeight.w500,
-                              color: isDark
-                                  ? AppTheme.backgroundColor
-                                  : AppTheme.zinc900,
-                            ),
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      localizations.studyScreenSectionIndicator(
-                        index + 1,
-                        total,
-                      ),
-                      style: TextStyle(
-                        fontSize: 11,
-                        fontWeight: FontWeight.w500,
-                        color: subtitleColor,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              if (isSelectionMode && widget.supportsReordering)
-                ReorderableDragStartListener(
-                  index: index,
-                  child: Padding(
-                    padding: const EdgeInsets.all(4.0),
-                    child: Icon(
-                      Icons.drag_indicator,
-                      color: Theme.of(context).hintColor,
-                    ),
-                  ),
-                )
-              else if (isSelectionMode)
-                Padding(
-                  padding: const EdgeInsets.all(4.0),
-                  child: Icon(
-                    Icons.drag_indicator,
-                    color: Theme.of(context).hintColor.withValues(alpha: 0.3),
-                  ),
-                )
-              else if (isCompleted)
-                const Icon(
-                  Icons.check_circle,
-                  size: 20,
-                  color: AppTheme.primaryColor,
-                )
-              else if (isDownloaded)
-                Icon(Icons.chevron_right, size: 18, color: arrowColor),
-            ],
-          ),
-          // AI Summary for completed or downloaded chunks
-          if (hasContent &&
-              chunk.aiSummary != null &&
-              chunk.aiSummary!.isNotEmpty) ...[
-            const SizedBox(height: 10),
-            LayoutBuilder(
-              builder: (context, constraints) {
-                final textSpan = TextSpan(
-                  text: chunk.aiSummary!,
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.normal,
-                    color: summaryColor,
-                    height: 1.45,
-                  ),
-                );
-                final tp = TextPainter(
-                  text: textSpan,
-                  maxLines: 3,
-                  textDirection: TextDirection.ltr,
-                )..layout(maxWidth: constraints.maxWidth);
-                final exceedsMaxLines = tp.didExceedMaxLines;
-
-                if (exceedsMaxLines != _exceedsMaxLines) {
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    if (mounted) {
-                      setState(() => _exceedsMaxLines = exceedsMaxLines);
-                    }
-                  });
-                }
-
-                return Text(
-                  chunk.aiSummary!,
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.normal,
-                    color: summaryColor,
-                    height: 1.45,
-                  ),
-                  maxLines: _expanded ? null : 3,
-                  overflow: _expanded ? null : TextOverflow.ellipsis,
-                );
-              },
-            ),
-            if (_exceedsMaxLines) ...[
-              const SizedBox(height: 4),
-              GestureDetector(
-                onTap: () => setState(() => _expanded = !_expanded),
-                child: Text(
-                  _expanded
-                      ? localizations.showLessLabel
-                      : localizations.showMoreLabel,
-                  style: const TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w500,
-                    color: AppTheme.primaryColor,
-                  ),
-                ),
-              ),
-            ],
-          ],
-          // Download button for created/error chunks
-          if (!isSelectionMode && needsDownload) ...[
-            const SizedBox(height: 12),
-            if ((chunk.status == StudyChunkState.created || isError) &&
-                widget.onEdit != null)
-              Row(
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Expanded(
-                    child: StudyIndexChunkDownloadButton(
-                      isError: isError,
-                      onDownload: widget.onDownload,
-                      localizations: localizations,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: widget.onEdit,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          vertical: 8,
-                          horizontal: 12,
-                        ),
-                        decoration: BoxDecoration(
-                          color: AppTheme.secondaryColor.withValues(
-                            alpha: isDark ? 0.15 : 0.1,
-                          ),
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            const Icon(
-                              Icons.add_outlined,
-                              size: 12,
-                              color: AppTheme.secondaryColor,
+                  Row(
+                    mainAxisSize: MainAxisSize.max,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      if (isSelectionMode)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 12),
+                          child: Container(
+                            width: 24,
+                            height: 24,
+                            decoration: BoxDecoration(
+                              color: isSelected
+                                  ? AppTheme.primaryColor
+                                  : Colors.transparent,
+                              shape: BoxShape.circle,
+                              border: Border.all(
+                                color: isSelected
+                                    ? AppTheme.primaryColor
+                                    : arrowColor,
+                              ),
                             ),
-                            const SizedBox(width: 4),
+                            child: isSelected
+                                ? const Icon(
+                                    LucideIcons.check,
+                                    size: 16,
+                                    color: Colors.white,
+                                  )
+                                : null,
+                          ),
+                        )
+                      else
+                        Container(
+                          width: 28,
+                          height: 28,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(14),
+                            color: isCompleted
+                                ? AppTheme.primaryColor
+                                : pendingBadgeBg,
+                          ),
+                          alignment: Alignment.center,
+                          child: Text(
+                            '${index + 1}',
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                              color: isCompleted
+                                  ? Colors.white
+                                  : pendingBadgeText,
+                            ),
+                          ),
+                        ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                Flexible(
+                                  child: Text(
+                                    chunk.title,
+                                    style: TextStyle(
+                                      fontSize: 14,
+                                      fontWeight: isCompleted
+                                          ? FontWeight.w600
+                                          : FontWeight.w500,
+                                      color: isDark
+                                          ? AppTheme.backgroundColor
+                                          : AppTheme.zinc900,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 2),
                             Text(
-                              localizations.create,
-                              style: const TextStyle(
+                              localizations.studyScreenSectionIndicator(
+                                index + 1,
+                                total,
+                              ),
+                              style: TextStyle(
                                 fontSize: 11,
-                                fontWeight: FontWeight.w600,
-                                color: AppTheme.secondaryColor,
+                                fontWeight: FontWeight.w500,
+                                color: subtitleColor,
                               ),
                             ),
                           ],
                         ),
                       ),
+                    ],
+                  ),
+
+                  // AI Summary for completed or downloaded chunks
+                  if (hasContent &&
+                      chunk.aiSummary != null &&
+                      chunk.aiSummary!.isNotEmpty) ...[
+                    const SizedBox(height: 10),
+                    LayoutBuilder(
+                      builder: (context, constraints) {
+                        final textSpan = TextSpan(
+                          text: chunk.aiSummary!,
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.normal,
+                            color: summaryColor,
+                            height: 1.45,
+                          ),
+                        );
+                        final tp = TextPainter(
+                          text: textSpan,
+                          maxLines: 3,
+                          textDirection: TextDirection.ltr,
+                        )..layout(maxWidth: constraints.maxWidth);
+                        final exceedsMaxLines = tp.didExceedMaxLines;
+
+                        if (exceedsMaxLines != _exceedsMaxLines) {
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            if (mounted) {
+                              setState(
+                                () => _exceedsMaxLines = exceedsMaxLines,
+                              );
+                            }
+                          });
+                        }
+
+                        return Text(
+                          chunk.aiSummary!,
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.normal,
+                            color: summaryColor,
+                            height: 1.45,
+                          ),
+                          maxLines: _expanded ? null : 3,
+                          overflow: _expanded ? null : TextOverflow.ellipsis,
+                        );
+                      },
                     ),
-                  ),
+                    if (_exceedsMaxLines) ...[
+                      const SizedBox(height: 4),
+                      GestureDetector(
+                        onTap: () => setState(() => _expanded = !_expanded),
+                        child: Text(
+                          _expanded
+                              ? localizations.showLessLabel
+                              : localizations.showMoreLabel,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w500,
+                            color: AppTheme.primaryColor,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                  // Download button for created/error chunks
+                  if (!isSelectionMode && needsDownload) ...[
+                    const SizedBox(height: 12),
+                    if ((chunk.status == StudyChunkState.created || isError) &&
+                        widget.onEdit != null)
+                      Row(
+                        children: [
+                          Expanded(
+                            child: StudyIndexChunkDownloadButton(
+                              isError: isError,
+                              onDownload: widget.onDownload,
+                              localizations: localizations,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: GestureDetector(
+                              onTap: widget.onEdit,
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 8,
+                                  horizontal: 12,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: AppTheme.secondaryColor.withValues(
+                                    alpha: isDark ? 0.15 : 0.1,
+                                  ),
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    const Icon(
+                                      Icons.add_outlined,
+                                      size: 12,
+                                      color: AppTheme.secondaryColor,
+                                    ),
+                                    const SizedBox(width: 4),
+                                    Text(
+                                      localizations.create,
+                                      style: const TextStyle(
+                                        fontSize: 11,
+                                        fontWeight: FontWeight.w600,
+                                        color: AppTheme.secondaryColor,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      )
+                    else
+                      StudyIndexChunkDownloadButton(
+                        isError: isError,
+                        onDownload: widget.onDownload,
+                        localizations: localizations,
+                      ),
+                  ],
+                  // Loading indicator while processing
+                  if (!isSelectionMode && isProcessing) ...[
+                    const SizedBox(height: 12),
+                    Row(
+                      children: [
+                        SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: AppTheme.primaryColor.withValues(alpha: 0.7),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          localizations.studyScreenGenerating,
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: subtitleColor,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
                 ],
-              )
-            else
-              StudyIndexChunkDownloadButton(
-                isError: isError,
-                onDownload: widget.onDownload,
-                localizations: localizations,
               ),
-          ],
-          // Loading indicator while processing
-          if (!isSelectionMode && isProcessing) ...[
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                SizedBox(
-                  width: 14,
-                  height: 14,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: AppTheme.primaryColor.withValues(alpha: 0.7),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  localizations.studyScreenGenerating,
-                  style: TextStyle(
-                    fontSize: 12,
-                    color: subtitleColor,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ],
             ),
-          ],
+          ),
+          if (isSelectionMode && widget.supportsReordering)
+            ReorderableDragStartListener(
+              index: index,
+              child: Padding(
+                padding: const EdgeInsets.all(10.0),
+                child: Icon(
+                  Icons.drag_indicator,
+                  color: Theme.of(context).hintColor,
+                ),
+              ),
+            )
+          else if (isSelectionMode)
+            Padding(
+              padding: const EdgeInsets.all(10.0),
+              child: Icon(
+                Icons.drag_indicator,
+                color: Theme.of(context).hintColor.withValues(alpha: 0.3),
+              ),
+            )
+          else if (isCompleted)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: Icon(
+                Icons.check_circle,
+                size: 22,
+                color: AppTheme.primaryColor,
+              ),
+            ),
         ],
       ),
     );
+
+    if (!isSelectionMode) {
+      cardContent = Stack(
+        children: [
+          cardContent,
+          Positioned(
+            top: 10,
+            right: 10,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AnimatedSize(
+                  duration: Durations.medium2,
+                  curve: Curves.easeInOutCubic,
+                  child:
+                      ((!isMobile && _isHovered) ||
+                          (isMobile && _isActionsExpanded))
+                      ? Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (widget.onEdit != null &&
+                                hasContent &&
+                                chunk.aiSummary != null &&
+                                chunk.aiSummary!.isNotEmpty) ...[
+                              _buildIconButton(
+                                icon: LucideIcons.pencil,
+                                color: AppTheme.secondaryColor,
+                                onPressed: widget.onEdit!,
+                                tooltip: localizations.edit,
+                              ),
+                              const SizedBox(width: 4),
+                            ],
+                            if (widget.onDelete != null) ...[
+                              _buildIconButton(
+                                icon: LucideIcons.trash2,
+                                color: theme.colorScheme.error,
+                                onPressed: widget.onDelete!,
+                                tooltip: localizations.deleteButton,
+                              ),
+                              const SizedBox(width: 4),
+                            ],
+                          ],
+                        )
+                      : const SizedBox.shrink(),
+                ),
+                if (isMobile)
+                  _buildIconButton(
+                    icon: _isActionsExpanded
+                        ? LucideIcons.chevronRight
+                        : Icons.more_horiz,
+                    color: Theme.of(context).hintColor,
+                    onPressed: () => setState(
+                      () => _isActionsExpanded = !_isActionsExpanded,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      );
+    }
 
     if (hasStatus) {
       cardContent = ClipRRect(
@@ -397,10 +487,36 @@ class _StudyIndexChunkCardState extends State<StudyIndexChunkCard> {
       );
     }
 
-    return GestureDetector(
-      onTap: (hasContent || isSelectionMode) ? onTap : null,
-      onLongPress: onLongPress,
-      child: cardContent,
+    return MouseRegion(
+      onEnter: (_) => setState(() => _isHovered = true),
+      onExit: (_) => setState(() => _isHovered = false),
+      child: GestureDetector(
+        onTap: (hasContent || isSelectionMode) ? onTap : null,
+        onLongPress: onLongPress,
+        child: cardContent,
+      ),
+    );
+  }
+
+  Widget _buildIconButton({
+    required IconData icon,
+    required Color color,
+    required VoidCallback onPressed,
+    String? tooltip,
+  }) {
+    return Container(
+      width: 32,
+      height: 32,
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: IconButton(
+        icon: Icon(icon, size: 16, color: color),
+        padding: EdgeInsets.zero,
+        onPressed: onPressed,
+        tooltip: tooltip,
+      ),
     );
   }
 }

--- a/lib/presentation/screens/widgets/study/study_index_view.dart
+++ b/lib/presentation/screens/widgets/study/study_index_view.dart
@@ -26,6 +26,7 @@ import 'package:quizdy/domain/use_cases/check_file_changes_use_case.dart';
 import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_bloc.dart';
 import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_event.dart';
 import 'package:quizdy/presentation/blocs/study_execution_bloc/study_execution_state.dart';
+import 'package:quizdy/presentation/screens/dialogs/custom_confirm_dialog.dart';
 import 'package:quizdy/presentation/screens/widgets/study/study_index_chunk_card.dart';
 import 'package:quizdy/presentation/screens/widgets/study/study_index_hero_card.dart';
 import 'package:quizdy/presentation/screens/widgets/study/study_index_sections_header.dart';
@@ -86,6 +87,29 @@ class StudyIndexView extends StatelessWidget {
     if (context.mounted) {
       context.read<StudyExecutionBloc>().add(
         DownloadStudyChunkRequested(index),
+      );
+    }
+  }
+
+  Future<void> _onChunkDelete(BuildContext context, int index) async {
+    final chunk = state.chunks[index];
+    final confirmed =
+        await showDialog<bool>(
+          context: context,
+          builder: (context) => CustomConfirmDialog(
+            title: AppLocalizations.of(context)!.confirmDeleteTitle,
+            message: AppLocalizations.of(
+              context,
+            )!.confirmDeleteMessage(chunk.title),
+            confirmText: AppLocalizations.of(context)!.deleteButton,
+            isDestructive: true,
+          ),
+        ) ??
+        false;
+
+    if (confirmed && context.mounted) {
+      context.read<StudyExecutionBloc>().add(
+        DeleteChunkAtIndexRequested(index),
       );
     }
   }
@@ -176,6 +200,7 @@ class StudyIndexView extends StatelessWidget {
               onEdit: onChunkEditTap != null
                   ? () => onChunkEditTap!(index)
                   : null,
+              onDelete: () => _onChunkDelete(context, index),
               onLongPress: () {
                 context.read<StudyExecutionBloc>().add(
                   ToggleChunkSelection(index),
@@ -236,6 +261,7 @@ class StudyIndexView extends StatelessWidget {
                 onEdit: onChunkEditTap != null
                     ? () => onChunkEditTap!(index)
                     : null,
+                onDelete: () => _onChunkDelete(context, index),
                 onLongPress: () {
                   context.read<StudyExecutionBloc>().add(
                     ToggleChunkSelection(index),
@@ -333,6 +359,7 @@ class StudyIndexView extends StatelessWidget {
                                 onEdit: onChunkEditTap != null
                                     ? () => onChunkEditTap!(i)
                                     : null,
+                                onDelete: () => _onChunkDelete(context, i),
                                 onLongPress: () {
                                   context.read<StudyExecutionBloc>().add(
                                     ToggleChunkSelection(i),
@@ -390,6 +417,7 @@ class StudyIndexView extends StatelessWidget {
                                 onEdit: onChunkEditTap != null
                                     ? () => onChunkEditTap!(i)
                                     : null,
+                                onDelete: () => _onChunkDelete(context, i),
                                 onLongPress: () {
                                   context.read<StudyExecutionBloc>().add(
                                     ToggleChunkSelection(i),


### PR DESCRIPTION
## Summary                                                                                                                                                                              
                                                                                                                                                                                          
  - Fixed AI Assistant button in question cards not updating when the API key is added or removed in Settings. Introduced a shared `ValueNotifier<bool>` in `ConfigurationService` that   
  fires on every key save/delete, and subscribed `QuestionListWidget` to it so the button shows/hides instantly without requiring navigation.                                             
  - Added Edit and Delete action buttons to `StudyIndexChunkCard`, matching the existing behavior in `QuestionPreviewCard`: hover reveal on desktop via `MouseRegion`, expandable toggle  
  on mobile, and a direct delete button when no edit action is available (no AI-generated content).                                                                                       
  - Added `DeleteChunkAtIndexRequested` bloc event with its handler: removes the chunk, re-indexes remaining chunks, adjusts `currentChunkIndex` and `selectedIndices`, and persists the  
  change.                                                                                                                                                                                 
  - Wired delete confirmation dialog (`CustomConfirmDialog`) through `StudyIndexView` for all four card instantiations (mobile list, mobile reorderable list, desktop even column, desktop
   odd column). 
- Fixes: https://github.com/vicajilau/quizdy/issues/379