### PR TITLE
Add home feedback survey CTA with full localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Implemented `CardStatusBar` and applied for `StudyIndexChunkCard` and `QuestionPreviewCard`.
 - feat(pdf): add export options dialog with questions, answers and study toggles.
 - feat(home): Added a new feedback survey CTA on Home that opens an external Google Form, with full localization in all supported languages.
+- feat(config): Added offline-first remote app config (GitHub-hosted JSON + cache/TTL) to control Home feedback visibility without requiring a new release, and prepared base keys for `latestVersion` and `minimumSupportedVersion`.
 - ux(quiz): Updated the quiz start dialog so the selected-questions action is primary, and the generic start action becomes secondary only when selections are available.
 - ux(quiz): Moved the missing explanation warning in question cards to its own line and added explanatory text in Quiz Preview.
 - ux(study): Updated the initial Study Mode action button from `Edit` to `Create` and replaced the pencil icon with an add icon.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: Implemented `CardStatusBar` and applied for `StudyIndexChunkCard` and `QuestionPreviewCard`.
 - feat(pdf): add export options dialog with questions, answers and study toggles.
+- feat(home): Added a new feedback survey CTA on Home that opens an external Google Form, with full localization in all supported languages.
 - ux(quiz): Updated the quiz start dialog so the selected-questions action is primary, and the generic start action becomes secondary only when selections are available.
 - ux(quiz): Moved the missing explanation warning in question cards to its own line and added explanatory text in Quiz Preview.
 - ux(study): Updated the initial Study Mode action button from `Edit` to `Create` and replaced the pencil icon with an add icon.

--- a/app_config.json
+++ b/app_config.json
@@ -1,0 +1,6 @@
+{
+  "homeFeedbackEnabled": false,
+  "homeFeedbackUrl": "https://docs.google.com/forms/d/e/1FAIpQLSd3NmQZyROb7Z_tnULmbJuBEJpOW02_EjcIRNBRVLsKF7lFHQ/viewform?usp=publish-editor",
+  "latestVersion": "1.13.0",
+  "minimumSupportedVersion": "1.0.0"
+}

--- a/app_config.json
+++ b/app_config.json
@@ -1,5 +1,5 @@
 {
-  "homeFeedbackEnabled": false,
+  "homeFeedbackEnabled": true,
   "homeFeedbackUrl": "https://docs.google.com/forms/d/e/1FAIpQLSd3NmQZyROb7Z_tnULmbJuBEJpOW02_EjcIRNBRVLsKF7lFHQ/viewform?usp=publish-editor",
   "latestVersion": "1.13.0",
   "minimumSupportedVersion": "1.0.0"

--- a/lib/core/l10n/app_ar.arb
+++ b/lib/core/l10n/app_ar.arb
@@ -2445,6 +2445,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "ملاحظاتك تهمنا",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "أجب عن استبيان سريع وساعدنا في تحسين Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorToggleEdit": "تحرير المحتوى",
   "studyEditorExitEdit": "الخروج من وضع التحرير",
   "studyEditorPages": "الصفحات",

--- a/lib/core/l10n/app_ca.arb
+++ b/lib/core/l10n/app_ca.arb
@@ -2133,6 +2133,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "La teva opinió ens importa",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Respon una enquesta ràpida i ajuda a millorar Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorToggleEdit": "Edita el contingut",
   "studyEditorExitEdit": "Sortiu del mode d'edició",
   "studyEditorPages": "Pàgines",

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -2127,6 +2127,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "Dein Feedback ist uns wichtig",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Beantworte eine kurze Umfrage und hilf dabei, Quizdy zu verbessern",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorToggleEdit": "Inhalte bearbeiten",
   "studyEditorExitEdit": "Bearbeitungsmodus verlassen",
   "studyEditorPages": "Seiten",

--- a/lib/core/l10n/app_el.arb
+++ b/lib/core/l10n/app_el.arb
@@ -1031,6 +1031,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "Η γνώμη σου μετράει",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Απάντησε σε μια σύντομη έρευνα και βοήθησε στη βελτίωση του Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorSaveChanges": "Αποθήκευση αλλαγών",
   "@studyEditorSaveChanges": {
     "description": "Button label to save edited component properties"

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -2134,6 +2134,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "Your feedback matters",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Answer a quick survey and help improve Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "onboardingBack": "Back",
   "@onboardingBack": {
     "description": "Back button in onboarding navigation"

--- a/lib/core/l10n/app_es.arb
+++ b/lib/core/l10n/app_es.arb
@@ -2057,6 +2057,14 @@
   "@supportDescription": {
     "description": "Descripción para la acción de soporte en ajustes"
   },
+  "feedbackTitle": "Tu opinión nos importa",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Responde una encuesta rápida y ayuda a mejorar Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "onboardingBack": "Atrás",
   "@onboardingBack": {
     "description": "Botón atrás en la navegación del onboarding"

--- a/lib/core/l10n/app_eu.arb
+++ b/lib/core/l10n/app_eu.arb
@@ -2031,6 +2031,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "Zure iritzia garrantzitsua da guretzat",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Erantzun inkesta labur bati eta lagundu Quizdy hobetzen",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorComponents": "Osagaiak",
   "@studyEditorComponents": {
     "description": "Section header for the list of components in the component editor"

--- a/lib/core/l10n/app_fr.arb
+++ b/lib/core/l10n/app_fr.arb
@@ -2076,6 +2076,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "Votre avis compte",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Répondez à un court sondage et aidez à améliorer Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorComponents": "Composants",
   "@studyEditorComponents": {
     "description": "Section header for the list of components in the component editor"

--- a/lib/core/l10n/app_gl.arb
+++ b/lib/core/l10n/app_gl.arb
@@ -2031,6 +2031,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "A túa opinión impórtanos",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Responde unha enquisa rápida e axuda a mellorar Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorComponents": "Compoñentes",
   "@studyEditorComponents": {
     "description": "Section header for the list of components in the component editor"

--- a/lib/core/l10n/app_hi.arb
+++ b/lib/core/l10n/app_hi.arb
@@ -2034,6 +2034,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "आपकी राय हमारे लिए महत्वपूर्ण है",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "एक छोटा सर्वे पूरा करें और Quizdy को बेहतर बनाने में मदद करें",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorSaveChanges": "परिवर्तनों को सुरक्षित करें",
   "@studyEditorSaveChanges": {
     "description": "Button label to save edited component properties"

--- a/lib/core/l10n/app_it.arb
+++ b/lib/core/l10n/app_it.arb
@@ -2085,6 +2085,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "La tua opinione conta",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Rispondi a un breve sondaggio e aiuta a migliorare Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorComponents": "Componenti",
   "@studyEditorComponents": {
     "description": "Section header for the list of components in the component editor"

--- a/lib/core/l10n/app_ja.arb
+++ b/lib/core/l10n/app_ja.arb
@@ -2034,6 +2034,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "あなたのご意見をお聞かせください",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "短いアンケートに回答して Quizdy の改善にご協力ください",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorComponents": "コンポーネント",
   "@studyEditorComponents": {
     "description": "Section header for the list of components in the component editor"

--- a/lib/core/l10n/app_ka.arb
+++ b/lib/core/l10n/app_ka.arb
@@ -723,6 +723,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "თქვენი აზრი ჩვენთვის მნიშვნელოვანია",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "უპასუხეთ მოკლე გამოკითხვას და დაგვეხმარეთ Quizdy-ის გაუმჯობესებაში",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorComponents": "კომპონენტები",
   "@studyEditorComponents": {
     "description": "Section header for the list of components in the component editor"

--- a/lib/core/l10n/app_ko.arb
+++ b/lib/core/l10n/app_ko.arb
@@ -723,6 +723,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "여러분의 의견은 소중합니다",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "짧은 설문에 답하고 Quizdy 개선에 도움을 주세요",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorPages": "페이지",
   "@studyEditorPages": {
     "description": "Section header for the list of pages in the section page manager"

--- a/lib/core/l10n/app_pt.arb
+++ b/lib/core/l10n/app_pt.arb
@@ -2122,6 +2122,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "A sua opinião é importante",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Responda a uma pesquisa rápida e ajude a melhorar o Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorPages": "Páginas",
   "@studyEditorPages": {
     "description": "Section header for the list of pages in the section page manager"

--- a/lib/core/l10n/app_ru.arb
+++ b/lib/core/l10n/app_ru.arb
@@ -738,6 +738,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "Ваше мнение важно для нас",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Пройдите короткий опрос и помогите улучшить Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorToggleEdit": "Редактировать контент",
   "@studyEditorToggleEdit": {
     "description": "Tooltip for the FAB button that enables study content edit mode"

--- a/lib/core/l10n/app_uk.arb
+++ b/lib/core/l10n/app_uk.arb
@@ -756,6 +756,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "Ваша думка важлива для нас",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "Пройдіть коротке опитування та допоможіть покращити Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorComponents": "компоненти",
   "@studyEditorComponents": {
     "description": "Section header for the list of components in the component editor"

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -2083,6 +2083,14 @@
   "@supportDescription": {
     "description": "Description for the support action in settings"
   },
+  "feedbackTitle": "你的反馈很重要",
+  "@feedbackTitle": {
+    "description": "Title for the home screen feedback prompt"
+  },
+  "feedbackDescription": "填写一份简短问卷，帮助改进 Quizdy",
+  "@feedbackDescription": {
+    "description": "Description for the home screen feedback prompt"
+  },
   "studyEditorToggleEdit": "编辑内容",
   "@studyEditorToggleEdit": {
     "description": "Tooltip for the FAB button that enables study content edit mode"

--- a/lib/core/service_locator.dart
+++ b/lib/core/service_locator.dart
@@ -64,7 +64,10 @@ class ServiceLocator {
     );
 
     getIt.registerSingleton<AppRemoteConfigService>(
-      AppRemoteConfigService(sharedPreferences: sharedPreferences),
+      AppRemoteConfigService(
+        sharedPreferences: sharedPreferences,
+        dio: dioClient,
+      ),
     );
 
     getIt.registerSingleton<AiRepositoryFactory>(

--- a/lib/core/service_locator.dart
+++ b/lib/core/service_locator.dart
@@ -21,6 +21,7 @@ import 'package:quizdy/data/repositories/ai/ai_repository_factory.dart';
 import 'package:quizdy/data/services/ai/ai_document_chunking_service.dart';
 import 'package:quizdy/data/services/ai/ai_jit_processing_service.dart';
 import 'package:quizdy/data/services/ai/ai_question_generation_service.dart';
+import 'package:quizdy/data/services/app_remote_config_service.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
 import 'package:quizdy/domain/use_cases/check_file_changes_use_case.dart';
 
@@ -60,6 +61,10 @@ class ServiceLocator {
 
     final configurationService = getIt.registerSingleton<ConfigurationService>(
       ConfigurationService(sharedPreferences: sharedPreferences),
+    );
+
+    getIt.registerSingleton<AppRemoteConfigService>(
+      AppRemoteConfigService(sharedPreferences: sharedPreferences),
     );
 
     getIt.registerSingleton<AiRepositoryFactory>(

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -14,7 +14,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:quizdy/core/theme/extensions/confirm_dialog_colors_extension.dart';
 import 'package:quizdy/core/theme/extensions/custom_colors.dart';
 import 'package:quizdy/core/theme/extensions/exam_timer_theme.dart';
@@ -84,7 +83,6 @@ class AppTheme {
     cardColor: cardColorLight,
     dividerColor: borderColor,
     hintColor: zinc400,
-    fontFamily: GoogleFonts.inter().fontFamily,
     colorScheme: const ColorScheme.light(
       primary: primaryColor,
       secondary: secondaryColor,
@@ -95,35 +93,32 @@ class AppTheme {
       onSurface: textColor,
       onError: Colors.white,
     ),
-    appBarTheme: AppBarTheme(
+    appBarTheme: const AppBarTheme(
       backgroundColor: surfaceColor,
       foregroundColor: textColor,
       elevation: 0,
       centerTitle: true,
-      titleTextStyle: GoogleFonts.plusJakartaSans(
+      titleTextStyle: TextStyle(
         color: textColor,
         fontSize: 20.0,
         fontWeight: FontWeight.bold,
       ),
-      iconTheme: const IconThemeData(color: textColor),
+      iconTheme: IconThemeData(color: textColor),
     ),
-    textTheme: TextTheme(
-      headlineLarge: GoogleFonts.plusJakartaSans(
+    textTheme: const TextTheme(
+      headlineLarge: TextStyle(
         fontSize: 48.0,
         fontWeight: FontWeight.w800,
         color: primaryColor,
       ),
-      headlineMedium: GoogleFonts.plusJakartaSans(
+      headlineMedium: TextStyle(
         fontSize: 24.0,
         fontWeight: FontWeight.bold,
         color: textColor,
       ),
-      bodyLarge: GoogleFonts.inter(fontSize: 16.0, color: textColor),
-      bodyMedium: GoogleFonts.inter(fontSize: 14.0, color: textSecondaryColor),
-      labelLarge: GoogleFonts.inter(
-        fontSize: 16.0,
-        fontWeight: FontWeight.w600,
-      ),
+      bodyLarge: TextStyle(fontSize: 16.0, color: textColor),
+      bodyMedium: TextStyle(fontSize: 14.0, color: textSecondaryColor),
+      labelLarge: TextStyle(fontSize: 16.0, fontWeight: FontWeight.w600),
     ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(
@@ -132,7 +127,7 @@ class AppTheme {
         elevation: 0,
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        textStyle: GoogleFonts.inter(fontSize: 16, fontWeight: FontWeight.w600),
+        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
       ),
     ),
     outlinedButtonTheme: OutlinedButtonThemeData(
@@ -142,7 +137,7 @@ class AppTheme {
         side: const BorderSide(color: borderColor, width: 2),
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        textStyle: GoogleFonts.inter(fontSize: 16, fontWeight: FontWeight.w600),
+        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
       ),
     ),
     iconTheme: const IconThemeData(color: textSecondaryColor, size: 24),
@@ -267,7 +262,6 @@ class AppTheme {
     cardColor: cardColorDark,
     dividerColor: borderColorDark,
     hintColor: zinc400,
-    fontFamily: GoogleFonts.inter().fontFamily,
     colorScheme: const ColorScheme.dark(
       primary: primaryColor,
       secondary: secondaryColor,
@@ -278,38 +272,35 @@ class AppTheme {
       onSurface: Color(0xFFFAFAFA), // Zinc 50
       onError: Colors.white,
     ),
-    appBarTheme: AppBarTheme(
-      backgroundColor: const Color(0xFF18181B),
+    appBarTheme: const AppBarTheme(
+      backgroundColor: Color(0xFF18181B),
       foregroundColor: Colors.white,
       elevation: 0,
       centerTitle: true,
-      titleTextStyle: GoogleFonts.plusJakartaSans(
+      titleTextStyle: TextStyle(
         color: Colors.white,
         fontSize: 20.0,
         fontWeight: FontWeight.bold,
       ),
-      iconTheme: const IconThemeData(color: Colors.white),
+      iconTheme: IconThemeData(color: Colors.white),
     ),
-    textTheme: TextTheme(
-      headlineLarge: GoogleFonts.plusJakartaSans(
+    textTheme: const TextTheme(
+      headlineLarge: TextStyle(
         fontSize: 48.0,
         fontWeight: FontWeight.w800,
         color: primaryColor,
       ),
-      headlineMedium: GoogleFonts.plusJakartaSans(
+      headlineMedium: TextStyle(
         fontSize: 24.0,
         fontWeight: FontWeight.bold,
         color: Colors.white,
       ),
-      bodyLarge: GoogleFonts.inter(fontSize: 16.0, color: Colors.white),
-      bodyMedium: GoogleFonts.inter(
+      bodyLarge: TextStyle(fontSize: 16.0, color: Colors.white),
+      bodyMedium: TextStyle(
         fontSize: 14.0,
-        color: const Color(0xFFA1A1AA), // Zinc 400
+        color: Color(0xFFA1A1AA), // Zinc 400
       ),
-      labelLarge: GoogleFonts.inter(
-        fontSize: 16.0,
-        fontWeight: FontWeight.w600,
-      ),
+      labelLarge: TextStyle(fontSize: 16.0, fontWeight: FontWeight.w600),
     ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(
@@ -318,7 +309,7 @@ class AppTheme {
         elevation: 0,
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        textStyle: GoogleFonts.inter(fontSize: 16, fontWeight: FontWeight.w600),
+        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
       ),
     ),
     outlinedButtonTheme: OutlinedButtonThemeData(
@@ -328,7 +319,7 @@ class AppTheme {
         side: const BorderSide(color: borderColorDark, width: 2), // Zinc 700
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        textStyle: GoogleFonts.inter(fontSize: 16, fontWeight: FontWeight.w600),
+        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
       ),
     ),
     iconTheme: const IconThemeData(

--- a/lib/data/services/app_remote_config_service.dart
+++ b/lib/data/services/app_remote_config_service.dart
@@ -141,7 +141,7 @@ class AppRemoteConfigService {
       printInDebug(
         '[AppRemoteConfigService] remote fetch failed, fallback path engaged: $error',
       );
-      if (cachedConfig != null) {
+      if (cachedConfig != null && !kDebugMode) {
         printInDebug('[AppRemoteConfigService] source=fallback_cache');
         return cachedConfig;
       }

--- a/lib/data/services/app_remote_config_service.dart
+++ b/lib/data/services/app_remote_config_service.dart
@@ -194,7 +194,7 @@ class AppRemoteConfigService {
   Future<AppRemoteConfig> _fetchRemoteConfig() async {
     final response = await http
         .get(
-          Uri.parse(_remoteConfigUrl),
+          Uri.parse('$_remoteConfigUrl?t=${DateTime.now().millisecondsSinceEpoch}'),
           headers: {'Accept': 'application/json'},
         )
         .timeout(const Duration(seconds: 6));

--- a/lib/data/services/app_remote_config_service.dart
+++ b/lib/data/services/app_remote_config_service.dart
@@ -80,7 +80,7 @@ class AppRemoteConfig {
 
 class AppRemoteConfigService {
   static const String _remoteConfigUrl =
-      'https://raw.githubusercontent.com/vicajilau/quizdy/feat/home-feedback-survey/app_config.json';
+      'https://raw.githubusercontent.com/vicajilau/quizdy/main/app_config.json';
   static const String _cachePayloadKey = 'remote_app_config_payload';
   static const String _cacheTimestampKey = 'remote_app_config_timestamp_ms';
   static const String _localConfigAssetPath = 'app_config.json';

--- a/lib/data/services/app_remote_config_service.dart
+++ b/lib/data/services/app_remote_config_service.dart
@@ -15,8 +15,9 @@
 
 import 'dart:convert';
 
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:quizdy/core/debug_print.dart';
 
@@ -46,8 +47,8 @@ class AppRemoteConfig {
   }
 
   factory AppRemoteConfig.fromJson(Map<String, dynamic> json) {
-    final feedbackEnabled = json['homeFeedbackEnabled'];
-    final feedbackUrl = json['homeFeedbackUrl'];
+    final bool? feedbackEnabled = json['homeFeedbackEnabled'];
+    final String? feedbackUrl = json['homeFeedbackUrl'];
 
     return AppRemoteConfig(
       homeFeedbackEnabled: feedbackEnabled is bool
@@ -70,7 +71,7 @@ class AppRemoteConfig {
     };
   }
 
-  static String? _asCleanString(dynamic value) {
+  static String? _asCleanString(Object? value) {
     if (value is! String) return null;
     final trimmed = value.trim();
     return trimmed.isEmpty ? null : trimmed;
@@ -83,12 +84,16 @@ class AppRemoteConfigService {
   static const String _cachePayloadKey = 'remote_app_config_payload';
   static const String _cacheTimestampKey = 'remote_app_config_timestamp_ms';
   static const String _localConfigAssetPath = 'app_config.json';
-  static const Duration _cacheTtl = Duration(hours: 6);
+  static const Duration _cacheTtl = Duration(hours: 1);
 
   final SharedPreferences _sharedPreferences;
+  final Dio _dio;
 
-  AppRemoteConfigService({required SharedPreferences sharedPreferences})
-    : _sharedPreferences = sharedPreferences;
+  AppRemoteConfigService({
+    required SharedPreferences sharedPreferences,
+    required Dio dio,
+  }) : _sharedPreferences = sharedPreferences,
+       _dio = dio;
 
   Future<AppRemoteConfig> getConfig({bool forceRefresh = false}) async {
     final cachedConfig = _readCachedConfig();
@@ -159,6 +164,8 @@ class AppRemoteConfigService {
   }
 
   bool _isCacheValid() {
+    if (kDebugMode) return false;
+
     final fetchedAtMs = _sharedPreferences.getInt(_cacheTimestampKey);
     if (fetchedAtMs == null) return false;
 
@@ -192,25 +199,33 @@ class AppRemoteConfigService {
   }
 
   Future<AppRemoteConfig> _fetchRemoteConfig() async {
-    final response = await http
-        .get(
-          Uri.parse('$_remoteConfigUrl?t=${DateTime.now().millisecondsSinceEpoch}'),
-          headers: {'Accept': 'application/json'},
-        )
-        .timeout(const Duration(seconds: 6));
+    final response = await _dio.get<Object>(
+      _remoteConfigUrl,
+      queryParameters: {'t': DateTime.now().millisecondsSinceEpoch},
+      options: Options(
+        headers: {'Accept': 'application/json'},
+        receiveTimeout: const Duration(seconds: 6),
+      ),
+    );
 
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw Exception(
-        'Remote config request failed with ${response.statusCode}',
-      );
+    final responseData = response.data;
+    final Map<String, dynamic> configMap;
+
+    if (responseData is String) {
+      final decoded = jsonDecode(responseData);
+      if (decoded is Map<String, dynamic>) {
+        configMap = decoded;
+      } else {
+        throw Exception('Remote config payload string is not a JSON object');
+      }
+    } else if (responseData is Map<String, dynamic>) {
+      configMap = responseData;
+    } else {
+      throw Exception('Remote config payload must be a JSON object or a string');
     }
 
-    final decoded = jsonDecode(response.body);
-    if (decoded is! Map<String, dynamic>) {
-      throw Exception('Remote config payload must be a JSON object');
-    }
-
-    return AppRemoteConfig.fromJson(decoded);
+    printInDebug('[AppRemoteConfigService] raw_body: $configMap');
+    return AppRemoteConfig.fromJson(configMap);
   }
 
   Future<AppRemoteConfig?> _loadLocalConfigAsset() async {

--- a/lib/data/services/app_remote_config_service.dart
+++ b/lib/data/services/app_remote_config_service.dart
@@ -1,0 +1,165 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AppRemoteConfig {
+  static const String defaultFeedbackUrl =
+      'https://docs.google.com/forms/d/e/1FAIpQLSd3NmQZyROb7Z_tnULmbJuBEJpOW02_EjcIRNBRVLsKF7lFHQ/viewform?usp=publish-editor';
+
+  final bool homeFeedbackEnabled;
+  final String? homeFeedbackUrl;
+  final String? latestVersion;
+  final String? minimumSupportedVersion;
+
+  const AppRemoteConfig({
+    required this.homeFeedbackEnabled,
+    required this.homeFeedbackUrl,
+    this.latestVersion,
+    this.minimumSupportedVersion,
+  });
+
+  factory AppRemoteConfig.defaults() {
+    return const AppRemoteConfig(
+      homeFeedbackEnabled: true,
+      homeFeedbackUrl: defaultFeedbackUrl,
+      latestVersion: null,
+      minimumSupportedVersion: null,
+    );
+  }
+
+  factory AppRemoteConfig.fromJson(Map<String, dynamic> json) {
+    final feedbackEnabled = json['homeFeedbackEnabled'];
+    final feedbackUrl = json['homeFeedbackUrl'];
+
+    return AppRemoteConfig(
+      homeFeedbackEnabled: feedbackEnabled is bool
+          ? feedbackEnabled
+          : AppRemoteConfig.defaults().homeFeedbackEnabled,
+      homeFeedbackUrl: feedbackUrl is String && feedbackUrl.trim().isNotEmpty
+          ? feedbackUrl.trim()
+          : null,
+      latestVersion: _asCleanString(json['latestVersion']),
+      minimumSupportedVersion: _asCleanString(json['minimumSupportedVersion']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'homeFeedbackEnabled': homeFeedbackEnabled,
+      'homeFeedbackUrl': homeFeedbackUrl,
+      'latestVersion': latestVersion,
+      'minimumSupportedVersion': minimumSupportedVersion,
+    };
+  }
+
+  static String? _asCleanString(dynamic value) {
+    if (value is! String) return null;
+    final trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+}
+
+class AppRemoteConfigService {
+  static const String _remoteConfigUrl =
+      'https://raw.githubusercontent.com/vicajilau/quizdy/main/app_config.json';
+  static const String _cachePayloadKey = 'remote_app_config_payload';
+  static const String _cacheTimestampKey = 'remote_app_config_timestamp_ms';
+  static const Duration _cacheTtl = Duration(hours: 6);
+
+  final SharedPreferences _sharedPreferences;
+
+  AppRemoteConfigService({required SharedPreferences sharedPreferences})
+    : _sharedPreferences = sharedPreferences;
+
+  Future<AppRemoteConfig> getConfig({bool forceRefresh = false}) async {
+    final cachedConfig = _readCachedConfig();
+
+    if (!forceRefresh && _isCacheValid()) {
+      if (cachedConfig != null) return cachedConfig;
+      return AppRemoteConfig.defaults();
+    }
+
+    try {
+      final remoteConfig = await _fetchRemoteConfig();
+      await _writeCache(remoteConfig);
+      return remoteConfig;
+    } catch (_) {
+      if (cachedConfig != null) return cachedConfig;
+      return AppRemoteConfig.defaults();
+    }
+  }
+
+  Future<AppRemoteConfig> refreshConfig() {
+    return getConfig(forceRefresh: true);
+  }
+
+  bool _isCacheValid() {
+    final fetchedAtMs = _sharedPreferences.getInt(_cacheTimestampKey);
+    if (fetchedAtMs == null) return false;
+
+    final fetchedAt = DateTime.fromMillisecondsSinceEpoch(fetchedAtMs);
+    final age = DateTime.now().difference(fetchedAt);
+    return age <= _cacheTtl;
+  }
+
+  AppRemoteConfig? _readCachedConfig() {
+    final payload = _sharedPreferences.getString(_cachePayloadKey);
+    if (payload == null || payload.isEmpty) return null;
+
+    try {
+      final jsonMap = jsonDecode(payload) as Map<String, dynamic>;
+      return AppRemoteConfig.fromJson(jsonMap);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _writeCache(AppRemoteConfig config) async {
+    await _sharedPreferences.setString(
+      _cachePayloadKey,
+      jsonEncode(config.toJson()),
+    );
+    await _sharedPreferences.setInt(
+      _cacheTimestampKey,
+      DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
+  Future<AppRemoteConfig> _fetchRemoteConfig() async {
+    final response = await http
+        .get(
+          Uri.parse(_remoteConfigUrl),
+          headers: {'Accept': 'application/json'},
+        )
+        .timeout(const Duration(seconds: 6));
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception(
+        'Remote config request failed with ${response.statusCode}',
+      );
+    }
+
+    final decoded = jsonDecode(response.body);
+    if (decoded is! Map<String, dynamic>) {
+      throw Exception('Remote config payload must be a JSON object');
+    }
+
+    return AppRemoteConfig.fromJson(decoded);
+  }
+}

--- a/lib/data/services/app_remote_config_service.dart
+++ b/lib/data/services/app_remote_config_service.dart
@@ -15,8 +15,10 @@
 
 import 'dart:convert';
 
+import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:quizdy/core/debug_print.dart';
 
 class AppRemoteConfig {
   static const String defaultFeedbackUrl =
@@ -36,7 +38,7 @@ class AppRemoteConfig {
 
   factory AppRemoteConfig.defaults() {
     return const AppRemoteConfig(
-      homeFeedbackEnabled: true,
+      homeFeedbackEnabled: false,
       homeFeedbackUrl: defaultFeedbackUrl,
       latestVersion: null,
       minimumSupportedVersion: null,
@@ -77,9 +79,10 @@ class AppRemoteConfig {
 
 class AppRemoteConfigService {
   static const String _remoteConfigUrl =
-      'https://raw.githubusercontent.com/vicajilau/quizdy/main/app_config.json';
+      'https://raw.githubusercontent.com/vicajilau/quizdy/feat/home-feedback-survey/app_config.json';
   static const String _cachePayloadKey = 'remote_app_config_payload';
   static const String _cacheTimestampKey = 'remote_app_config_timestamp_ms';
+  static const String _localConfigAssetPath = 'app_config.json';
   static const Duration _cacheTtl = Duration(hours: 6);
 
   final SharedPreferences _sharedPreferences;
@@ -89,19 +92,65 @@ class AppRemoteConfigService {
 
   Future<AppRemoteConfig> getConfig({bool forceRefresh = false}) async {
     final cachedConfig = _readCachedConfig();
+    final isCacheValid = _isCacheValid();
 
-    if (!forceRefresh && _isCacheValid()) {
-      if (cachedConfig != null) return cachedConfig;
-      return AppRemoteConfig.defaults();
+    printInDebug(
+      '[AppRemoteConfigService] getConfig(forceRefresh: $forceRefresh, '
+      'cacheValid: $isCacheValid)',
+    );
+    if (cachedConfig != null) {
+      _logConfig('cache_read', cachedConfig);
+    } else {
+      printInDebug('[AppRemoteConfigService] cache_read -> <empty>');
+    }
+
+    if (!forceRefresh && isCacheValid) {
+      if (cachedConfig != null) {
+        printInDebug('[AppRemoteConfigService] source=cache');
+        return cachedConfig;
+      }
+
+      final localConfig = await _loadLocalConfigAsset();
+      if (localConfig != null) {
+        printInDebug(
+          '[AppRemoteConfigService] cache valid but payload missing, source=local_asset',
+        );
+        return localConfig;
+      }
+
+      final defaults = AppRemoteConfig.defaults();
+      printInDebug(
+        '[AppRemoteConfigService] cache valid but payload missing, source=defaults',
+      );
+      _logConfig('defaults_returned', defaults);
+      return defaults;
     }
 
     try {
       final remoteConfig = await _fetchRemoteConfig();
+      _logConfig('remote_fetched', remoteConfig);
       await _writeCache(remoteConfig);
+      printInDebug('[AppRemoteConfigService] source=remote');
       return remoteConfig;
-    } catch (_) {
-      if (cachedConfig != null) return cachedConfig;
-      return AppRemoteConfig.defaults();
+    } catch (error) {
+      printInDebug(
+        '[AppRemoteConfigService] remote fetch failed, fallback path engaged: $error',
+      );
+      if (cachedConfig != null) {
+        printInDebug('[AppRemoteConfigService] source=fallback_cache');
+        return cachedConfig;
+      }
+
+      final localConfig = await _loadLocalConfigAsset();
+      if (localConfig != null) {
+        printInDebug('[AppRemoteConfigService] source=fallback_local_asset');
+        return localConfig;
+      }
+
+      final defaults = AppRemoteConfig.defaults();
+      printInDebug('[AppRemoteConfigService] source=fallback_defaults');
+      _logConfig('defaults_returned', defaults);
+      return defaults;
     }
   }
 
@@ -131,6 +180,7 @@ class AppRemoteConfigService {
   }
 
   Future<void> _writeCache(AppRemoteConfig config) async {
+    _logConfig('cache_write', config);
     await _sharedPreferences.setString(
       _cachePayloadKey,
       jsonEncode(config.toJson()),
@@ -161,5 +211,32 @@ class AppRemoteConfigService {
     }
 
     return AppRemoteConfig.fromJson(decoded);
+  }
+
+  Future<AppRemoteConfig?> _loadLocalConfigAsset() async {
+    try {
+      final payload = await rootBundle.loadString(_localConfigAssetPath);
+      if (payload.trim().isEmpty) return null;
+
+      final decoded = jsonDecode(payload);
+      if (decoded is! Map<String, dynamic>) return null;
+
+      final config = AppRemoteConfig.fromJson(decoded);
+      _logConfig('local_asset_read', config);
+      return config;
+    } catch (error) {
+      printInDebug('[AppRemoteConfigService] local asset load failed: $error');
+      return null;
+    }
+  }
+
+  void _logConfig(String source, AppRemoteConfig config) {
+    printInDebug(
+      '[AppRemoteConfigService][$source] '
+      'homeFeedbackEnabled=${config.homeFeedbackEnabled}, '
+      'homeFeedbackUrl=${config.homeFeedbackUrl}, '
+      'latestVersion=${config.latestVersion}, '
+      'minimumSupportedVersion=${config.minimumSupportedVersion}',
+    );
   }
 }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -41,6 +41,7 @@ import 'package:quizdy/domain/models/quiz/quiz_file.dart';
 import 'package:quizdy/domain/models/quiz/study_chunk.dart';
 import 'package:quizdy/presentation/screens/dialogs/custom_confirm_dialog.dart';
 import 'package:quizdy/presentation/screens/dialogs/mode_selection_dialog.dart';
+import 'package:quizdy/data/services/app_remote_config_service.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
 import 'package:quizdy/data/services/ai/ai_question_generation_service.dart';
 import 'package:quizdy/core/extensions/string_extension.dart';
@@ -62,9 +63,28 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   bool _isDragging = false;
   bool _isLoading = false;
+  bool _showFeedbackBanner = AppRemoteConfig.defaults().homeFeedbackEnabled;
+  String? _feedbackFormUrl = AppRemoteConfig.defaults().homeFeedbackUrl;
   String? _loadingText;
   QuizMode? _hoveredDropMode;
   QuizMode? _pendingDropMode;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadRemoteConfig();
+  }
+
+  Future<void> _loadRemoteConfig() async {
+    final remoteConfig = await ServiceLocator.getIt<AppRemoteConfigService>()
+        .getConfig();
+    if (!mounted) return;
+
+    setState(() {
+      _showFeedbackBanner = remoteConfig.homeFeedbackEnabled;
+      _feedbackFormUrl = remoteConfig.homeFeedbackUrl;
+    });
+  }
 
   void _navigateByMode(BuildContext context, QuizMode mode, QuizFile quizFile) {
     if (mode == QuizMode.study) {
@@ -141,9 +161,17 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Future<void> _openFeedbackForm(BuildContext context) async {
-    final url = Uri.parse(
-      'https://docs.google.com/forms/d/e/1FAIpQLSd3NmQZyROb7Z_tnULmbJuBEJpOW02_EjcIRNBRVLsKF7lFHQ/viewform?usp=publish-editor',
-    );
+    final urlRaw = _feedbackFormUrl;
+    if (urlRaw == null || urlRaw.trim().isEmpty) {
+      context.presentSnackBar(AppLocalizations.of(context)!.featureComingSoon);
+      return;
+    }
+
+    final url = Uri.tryParse(urlRaw.trim());
+    if (url == null) {
+      context.presentSnackBar(AppLocalizations.of(context)!.featureComingSoon);
+      return;
+    }
 
     if (await canLaunchUrl(url)) {
       await launchUrl(url, mode: LaunchMode.externalApplication);
@@ -528,6 +556,7 @@ class _HomeScreenState extends State<HomeScreen> {
                                 ),
                                 HomeFooterWidget(
                                   isLoading: _isLoading,
+                                  showFeedbackBanner: _showFeedbackBanner,
                                   onCreateTap: () =>
                                       _showCreateQuizFileDialog(context),
                                   onGenerateAITap: () =>

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -17,6 +17,7 @@ import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:quizdy/core/context_extension.dart';
 import 'package:quizdy/core/service_locator.dart';
 import 'package:quizdy/domain/models/custom_exceptions/bad_quiz_file_exception.dart';
@@ -137,6 +138,20 @@ class _HomeScreenState extends State<HomeScreen> {
       barrierDismissible: false,
       builder: (_) => const SettingsDialog(),
     );
+  }
+
+  Future<void> _openFeedbackForm(BuildContext context) async {
+    final url = Uri.parse(
+      'https://docs.google.com/forms/d/e/1FAIpQLSd3NmQZyROb7Z_tnULmbJuBEJpOW02_EjcIRNBRVLsKF7lFHQ/viewform?usp=publish-editor',
+    );
+
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
+    } else if (context.mounted) {
+      context.presentSnackBar(
+        AppLocalizations.of(context)!.couldNotOpenUrl(url.toString()),
+      );
+    }
   }
 
   Future<void> _generateQuestionsWithAI(BuildContext context) async {
@@ -519,6 +534,8 @@ class _HomeScreenState extends State<HomeScreen> {
                                       _generateQuestionsWithAI(context),
                                   onStudyModeTap: () =>
                                       _startStudyModeWithAI(context),
+                                  onFeedbackTap: () =>
+                                      _openFeedbackForm(context),
                                 ),
                               ],
                             ),

--- a/lib/presentation/screens/onboarding/widgets/onboarding_desktop_layout.dart
+++ b/lib/presentation/screens/onboarding/widgets/onboarding_desktop_layout.dart
@@ -14,7 +14,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/presentation/blocs/onboarding_cubit/onboarding_cubit.dart';
 import 'package:quizdy/presentation/blocs/onboarding_cubit/onboarding_state.dart';
@@ -165,7 +164,7 @@ class OnboardingDesktopPageContent extends StatelessWidget {
               children: [
                 Text(
                   page.title,
-                  style: GoogleFonts.plusJakartaSans(
+                  style: theme.textTheme.headlineMedium?.copyWith(
                     fontSize: 36,
                     fontWeight: FontWeight.w700,
                     color: theme.colorScheme.onSurface,

--- a/lib/presentation/screens/onboarding/widgets/onboarding_mobile_layout.dart
+++ b/lib/presentation/screens/onboarding/widgets/onboarding_mobile_layout.dart
@@ -14,7 +14,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/presentation/blocs/onboarding_cubit/onboarding_cubit.dart';
 import 'package:quizdy/presentation/blocs/onboarding_cubit/onboarding_state.dart';
@@ -144,7 +143,7 @@ class OnboardingMobilePageContent extends StatelessWidget {
           Text(
             page.title,
             textAlign: TextAlign.center,
-            style: GoogleFonts.plusJakartaSans(
+            style: theme.textTheme.headlineMedium?.copyWith(
               fontSize: 28,
               fontWeight: FontWeight.w700,
               color: theme.colorScheme.onSurface,

--- a/lib/presentation/screens/widgets/home/home_feedback_banner.dart
+++ b/lib/presentation/screens/widgets/home/home_feedback_banner.dart
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+
+class HomeFeedbackBanner extends StatelessWidget {
+  final bool isLoading;
+  final VoidCallback onTap;
+
+  const HomeFeedbackBanner({
+    super.key,
+    required this.isLoading,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final primary = theme.colorScheme.primary;
+    final primaryTint = primary.withValues(
+      alpha: theme.brightness == Brightness.dark ? 0.18 : 0.08,
+    );
+
+    return Material(
+      color: primaryTint,
+      borderRadius: BorderRadius.circular(18),
+      child: InkWell(
+        onTap: isLoading ? null : onTap,
+        borderRadius: BorderRadius.circular(18),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(color: primary.withValues(alpha: 0.24)),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.surface.withValues(alpha: 0.8),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Icon(LucideIcons.gift, color: primary, size: 20),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      AppLocalizations.of(context)!.feedbackTitle,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      AppLocalizations.of(context)!.feedbackDescription,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Icon(LucideIcons.chevronRight, color: primary, size: 18),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/widgets/home/home_footer_widget.dart
+++ b/lib/presentation/screens/widgets/home/home_footer_widget.dart
@@ -20,6 +20,7 @@ import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/core/theme/app_theme.dart';
 import 'package:quizdy/presentation/blocs/file_bloc/file_bloc.dart';
 import 'package:quizdy/presentation/blocs/file_bloc/file_event.dart';
+import 'package:quizdy/presentation/screens/widgets/home/home_feedback_banner.dart';
 import 'package:quizdy/presentation/widgets/quizdy_button.dart';
 
 class HomeFooterWidget extends StatelessWidget {
@@ -27,6 +28,7 @@ class HomeFooterWidget extends StatelessWidget {
   final VoidCallback onCreateTap;
   final VoidCallback onGenerateAITap;
   final VoidCallback onStudyModeTap;
+  final VoidCallback onFeedbackTap;
 
   const HomeFooterWidget({
     super.key,
@@ -34,6 +36,7 @@ class HomeFooterWidget extends StatelessWidget {
     required this.onCreateTap,
     required this.onGenerateAITap,
     required this.onStudyModeTap,
+    required this.onFeedbackTap,
   });
 
   @override
@@ -87,6 +90,13 @@ class HomeFooterWidget extends StatelessWidget {
                   ),
                 ),
               ],
+            ),
+          ),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 620),
+            child: HomeFeedbackBanner(
+              isLoading: isLoading,
+              onTap: onFeedbackTap,
             ),
           ),
         ],

--- a/lib/presentation/screens/widgets/home/home_footer_widget.dart
+++ b/lib/presentation/screens/widgets/home/home_footer_widget.dart
@@ -25,6 +25,7 @@ import 'package:quizdy/presentation/widgets/quizdy_button.dart';
 
 class HomeFooterWidget extends StatelessWidget {
   final bool isLoading;
+  final bool showFeedbackBanner;
   final VoidCallback onCreateTap;
   final VoidCallback onGenerateAITap;
   final VoidCallback onStudyModeTap;
@@ -33,6 +34,7 @@ class HomeFooterWidget extends StatelessWidget {
   const HomeFooterWidget({
     super.key,
     required this.isLoading,
+    required this.showFeedbackBanner,
     required this.onCreateTap,
     required this.onGenerateAITap,
     required this.onStudyModeTap,
@@ -92,13 +94,14 @@ class HomeFooterWidget extends StatelessWidget {
               ],
             ),
           ),
-          ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 620),
-            child: HomeFeedbackBanner(
-              isLoading: isLoading,
-              onTap: onFeedbackTap,
+          if (showFeedbackBanner)
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 620),
+              child: HomeFeedbackBanner(
+                isLoading: isLoading,
+                onTap: onFeedbackTap,
+              ),
             ),
-          ),
         ],
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -381,14 +381,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "17.2.1"
-  google_fonts:
-    dependency: "direct main"
-    description:
-      name: google_fonts
-      sha256: db9df7a5898d894eeda4c78143f35c30a243558be439518972366880b80bf88e
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.0.2"
   gpt_markdown:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -398,7 +398,7 @@ packages:
     source: hosted
     version: "1.0.2"
   http:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,6 @@ dependencies:
   url_launcher: ^6.3.2
   gpt_markdown: ^1.1.6
   flutter_math_fork: ^0.7.2
-  google_fonts: ^8.0.2
   lucide_icons: ^0.257.0
   qr_flutter: ^4.1.0
   path_provider: ^2.1.5
@@ -98,6 +97,7 @@ flutter:
     - images/
     - PRIVACY.md
     - CHANGELOG.md
+    - app_config.json
 
 # Configuración para flutter_launcher_icons
 flutter_launcher_icons:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,6 @@ dependencies:
   flutter_launcher_icons: ^0.14.4
   shared_preferences: ^2.5.5
   web: ^1.1.1
-  http: ^1.6.0
   crypto: ^3.0.7
   url_launcher: ^6.3.2
   gpt_markdown: ^1.1.6

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -20,16 +20,37 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:quizdy/core/service_locator.dart';
+import 'package:quizdy/data/services/app_remote_config_service.dart';
 import 'package:quizdy/main.dart';
 import 'package:quizdy/routes/app_router.dart';
+
+class _TestAppRemoteConfigService extends AppRemoteConfigService {
+  _TestAppRemoteConfigService({required super.sharedPreferences})
+    : super(dio: Dio());
+
+  @override
+  Future<AppRemoteConfig> getConfig({bool forceRefresh = false}) async {
+    return AppRemoteConfig.defaults();
+  }
+}
 
 void main() {
   setUpAll(() async {
     SharedPreferences.setMockInitialValues({});
     await ServiceLocator.setup();
+
+    final sharedPreferences = await SharedPreferences.getInstance();
+    final getIt = ServiceLocator.getIt;
+    if (getIt.isRegistered<AppRemoteConfigService>()) {
+      getIt.unregister<AppRemoteConfigService>();
+    }
+    getIt.registerSingleton<AppRemoteConfigService>(
+      _TestAppRemoteConfigService(sharedPreferences: sharedPreferences),
+    );
   });
 
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -413,14 +413,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "17.2.2"
-  google_fonts:
-    dependency: transitive
-    description:
-      name: google_fonts
-      sha256: db9df7a5898d894eeda4c78143f35c30a243558be439518972366880b80bf88e
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.0.2"
   gpt_markdown:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- add a new Home footer feedback CTA that opens an external Google Form
- add URL launch fallback handling with snackbar feedback on failure
- extract the feedback banner into a dedicated widget file
- add and translate `feedbackTitle` and `feedbackDescription` across all supported locales
- add changelog entry for this feature and link the tracking issue

Fixes #390