### PR TITLE
Update onboarding feature title to reflect 18 language support

### DIFF
--- a/lib/core/l10n/app_ar.arb
+++ b/lib/core/l10n/app_ar.arb
@@ -2010,7 +2010,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "وصف الميزة في صفحة الترحيب بالعرض الترحيبي"
   },
-  "onboardingFeatureLanguagesTitle": "دعم 13 لغة",
+  "onboardingFeatureLanguagesTitle": "دعم 18 لغة",
   "@onboardingFeatureLanguagesTitle": {
     "description": "عنوان الميزة في صفحة الترحيب بالعرض الترحيبي"
   },

--- a/lib/core/l10n/app_ca.arb
+++ b/lib/core/l10n/app_ca.arb
@@ -1858,7 +1858,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "Descripció de la funció a la pàgina de benvinguda"
   },
-  "onboardingFeatureLanguagesTitle": "13 idiomes compatibles",
+  "onboardingFeatureLanguagesTitle": "18 idiomes compatibles",
   "@onboardingFeatureLanguagesTitle": {
     "description": "Títol de la funció a la pàgina de benvinguda"
   },

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -1852,7 +1852,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "Funktionsbeschreibung auf der Onboarding-Begrüßungsseite"
   },
-  "onboardingFeatureLanguagesTitle": "13 Sprachen unterstützt",
+  "onboardingFeatureLanguagesTitle": "18 Sprachen unterstützt",
   "@onboardingFeatureLanguagesTitle": {
     "description": "Funktionstitel auf der Onboarding-Begrüßungsseite"
   },

--- a/lib/core/l10n/app_el.arb
+++ b/lib/core/l10n/app_el.arb
@@ -741,7 +741,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "Περιγραφή λειτουργίας στη σελίδα καλωσορίσματος"
   },
-  "onboardingFeatureLanguagesTitle": "Υποστήριξη 13 γλωσσών",
+  "onboardingFeatureLanguagesTitle": "Υποστήριξη 18 γλωσσών",
   "@onboardingFeatureLanguagesTitle": {
     "description": "Τίτλος λειτουργίας στη σελίδα καλωσορίσματος"
   },

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -2214,7 +2214,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "Feature description in onboarding welcome page"
   },
-  "onboardingFeatureLanguagesTitle": "13 languages supported",
+  "onboardingFeatureLanguagesTitle": "18 languages supported",
   "@onboardingFeatureLanguagesTitle": {
     "description": "Feature title in onboarding welcome page"
   },

--- a/lib/core/l10n/app_es.arb
+++ b/lib/core/l10n/app_es.arb
@@ -2137,7 +2137,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "Descripción de característica en la página de bienvenida del onboarding"
   },
-  "onboardingFeatureLanguagesTitle": "13 idiomas soportados",
+  "onboardingFeatureLanguagesTitle": "18 idiomas soportados",
   "@onboardingFeatureLanguagesTitle": {
     "description": "Título de característica en la página de bienvenida del onboarding"
   },

--- a/lib/core/l10n/app_eu.arb
+++ b/lib/core/l10n/app_eu.arb
@@ -1752,7 +1752,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "Funtzioaren deskribapena ongietorri orrialdean"
   },
-  "onboardingFeatureLanguagesTitle": "13 hizkuntza onartzen dira",
+  "onboardingFeatureLanguagesTitle": "18 hizkuntza onartzen dira",
   "@onboardingFeatureLanguagesTitle": {
     "description": "Funtzioaren titulua ongietorri orrialdean"
   },

--- a/lib/core/l10n/app_fr.arb
+++ b/lib/core/l10n/app_fr.arb
@@ -1797,7 +1797,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "Description de la fonctionnalité sur la page d'accueil"
   },
-  "onboardingFeatureLanguagesTitle": "13 langues supportées",
+  "onboardingFeatureLanguagesTitle": "18 langues supportées",
   "@onboardingFeatureLanguagesTitle": {
     "description": "Titre de la fonctionnalité sur la page d'accueil"
   },

--- a/lib/core/l10n/app_gl.arb
+++ b/lib/core/l10n/app_gl.arb
@@ -1752,7 +1752,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "Descrición da función na páxina de benvida"
   },
-  "onboardingFeatureLanguagesTitle": "13 idiomas compatibles",
+  "onboardingFeatureLanguagesTitle": "18 idiomas compatibles",
   "@onboardingFeatureLanguagesTitle": {
     "description": "Título da función na páxina de benvida"
   },

--- a/lib/core/l10n/app_hi.arb
+++ b/lib/core/l10n/app_hi.arb
@@ -1747,7 +1747,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "स्वागत पृष्ठ पर सुविधा विवरण"
   },
-  "onboardingFeatureLanguagesTitle": "13 भाषाओं का समर्थन",
+  "onboardingFeatureLanguagesTitle": "18 भाषाओं का समर्थन",
   "@onboardingFeatureLanguagesTitle": {
     "description": "स्वागत पृष्ठ पर सुविधा शीर्षक"
   },

--- a/lib/core/l10n/app_it.arb
+++ b/lib/core/l10n/app_it.arb
@@ -1827,7 +1827,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "Descripzione della funzione nella pagina di benvenuto"
   },
-  "onboardingFeatureLanguagesTitle": "13 lingue supportate",
+  "onboardingFeatureLanguagesTitle": "18 lingue supportate",
   "@onboardingFeatureLanguagesTitle": {
     "description": "Titolo della funzione nella pagina di benvenuto"
   },

--- a/lib/core/l10n/app_ja.arb
+++ b/lib/core/l10n/app_ja.arb
@@ -1755,7 +1755,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "ウェルカムページの機能説明"
   },
-  "onboardingFeatureLanguagesTitle": "13言語に対応",
+  "onboardingFeatureLanguagesTitle": "18言語に対応",
   "@onboardingFeatureLanguagesTitle": {
     "description": "ウェルカムページの機能タイトル"
   },

--- a/lib/core/l10n/app_ka.arb
+++ b/lib/core/l10n/app_ka.arb
@@ -552,7 +552,7 @@
   "onboardingFeatureAiDescription": "შექმენით ქვიზები ნებისმიერი ტექსტიდან Gemini-ს ან GPT-ის მეშვეობით",
   "onboardingFeatureTypesTitle": "მრავალი ტიპის კითხვა",
   "onboardingFeatureTypesDescription": "ერთჯერადი არჩევანი, მრავალჯერადი არჩევანი, ჭეშმარიტი/მცდარი და ესე",
-  "onboardingFeatureLanguagesTitle": "13 ენის მხარდაჭერა",
+  "onboardingFeatureLanguagesTitle": "18 ენის მხარდაჭერა",
   "onboardingFeatureLanguagesDescription": "შექმენით და გაიარეთ ქვიზები სხვადასხვა ენაზე",
   "onboardingStepCreateTitle": "ქვიზის შექმნა",
   "onboardingStepCreateDescription": "დაიწყეთ ნულიდან თქვენი საკუთარი კითხვებით",

--- a/lib/core/l10n/app_ko.arb
+++ b/lib/core/l10n/app_ko.arb
@@ -552,7 +552,7 @@
   "onboardingFeatureAiDescription": "Gemini 또는 GPT를 사용하여 모든 텍스트에서 퀴즈 생성",
   "onboardingFeatureTypesTitle": "다양한 질문 유형",
   "onboardingFeatureTypesDescription": "단일 선택, 다중 선택, 참/거짓 및 주관식",
-  "onboardingFeatureLanguagesTitle": "13개 언어 지원",
+  "onboardingFeatureLanguagesTitle": "18개 언어 지원",
   "onboardingFeatureLanguagesDescription": "여러 언어로 퀴즈를 생성하고 응시하세요",
   "onboardingStepCreateTitle": "퀴즈 생성",
   "onboardingStepCreateDescription": "나만의 질문으로 처음부터 시작하세요",

--- a/lib/core/l10n/app_pt.arb
+++ b/lib/core/l10n/app_pt.arb
@@ -1835,7 +1835,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "Descrição do recurso na página de boas-vindas"
   },
-  "onboardingFeatureLanguagesTitle": "13 idiomas suportados",
+  "onboardingFeatureLanguagesTitle": "18 idiomas suportados",
   "@onboardingFeatureLanguagesTitle": {
     "description": "Título do recurso na página de boas-vindas"
   },

--- a/lib/core/l10n/app_ru.arb
+++ b/lib/core/l10n/app_ru.arb
@@ -567,7 +567,7 @@
   "onboardingFeatureAiDescription": "Создавайте квизы из любого текста с Gemini или GPT",
   "onboardingFeatureTypesTitle": "Различные типы вопросов",
   "onboardingFeatureTypesDescription": "Одиночный выбор, множественный выбор, верно/неверно и эссе",
-  "onboardingFeatureLanguagesTitle": "Поддержка 13 языков",
+  "onboardingFeatureLanguagesTitle": "Поддержка 18 языков",
   "onboardingFeatureLanguagesDescription": "Создавайте и проходите квизы на нескольких языках",
   "onboardingStepCreateTitle": "Создать квиз",
   "onboardingStepCreateDescription": "Начните с нуля со своими собственными вопросами",

--- a/lib/core/l10n/app_uk.arb
+++ b/lib/core/l10n/app_uk.arb
@@ -586,7 +586,7 @@
   "onboardingFeatureAiDescription": "Створюйте квізи з будь-якого тексту з Gemini або GPT",
   "onboardingFeatureTypesTitle": "Різні типи питань",
   "onboardingFeatureTypesDescription": "Одиночний вибір, множинний вибір, вірно/невірно та есе",
-  "onboardingFeatureLanguagesTitle": "Підтримка 13 мов",
+  "onboardingFeatureLanguagesTitle": "Підтримка 18 мов",
   "onboardingFeatureLanguagesDescription": "Створюйте та проходьте квізи кількома мовами",
   "onboardingStepCreateTitle": "Створити квіз",
   "onboardingStepCreateDescription": "Почніть з нуля зі своїми власними питаннями",

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -1796,7 +1796,7 @@
   "@onboardingFeatureTypesDescription": {
     "description": "欢迎页面的功能描述"
   },
-  "onboardingFeatureLanguagesTitle": "支持 13 种语言",
+  "onboardingFeatureLanguagesTitle": "支持 18 种语言",
   "@onboardingFeatureLanguagesTitle": {
     "description": "欢迎页面的功能标题"
   },


### PR DESCRIPTION
This pull request updates the onboarding feature description across all supported languages to reflect that the app now supports 18 languages instead of 13. The change ensures consistency in the user-facing onboarding text in every localization file.