### PR TITLE
Refactor SmartAppBanner layout and button styles for mobile

### DIFF
--- a/lib/presentation/widgets/smart_app_banner.dart
+++ b/lib/presentation/widgets/smart_app_banner.dart
@@ -16,6 +16,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:quizdy/core/context_extension.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -87,8 +88,6 @@ class _SmartAppBannerState extends State<SmartAppBanner> {
 
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
-    final screenWidth = MediaQuery.of(context).size.width;
-    final isCompact = screenWidth < 500;
 
     return Column(
       children: [
@@ -143,7 +142,7 @@ class _SmartAppBannerState extends State<SmartAppBanner> {
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
-                        if (!isCompact)
+                        if (!context.isMobile)
                           Text(
                             l10n.openInQuizdyApp,
                             style: theme.textTheme.bodySmall?.copyWith(
@@ -158,7 +157,7 @@ class _SmartAppBannerState extends State<SmartAppBanner> {
                   ),
                   const SizedBox(width: 8),
                   if (_storeUrl.isNotEmpty) ...[
-                    if (isCompact)
+                    if (context.isMobile)
                       Tooltip(
                         message: l10n.installApp,
                         child: OutlinedButton(

--- a/lib/presentation/widgets/smart_app_banner.dart
+++ b/lib/presentation/widgets/smart_app_banner.dart
@@ -87,6 +87,8 @@ class _SmartAppBannerState extends State<SmartAppBanner> {
 
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
+    final screenWidth = MediaQuery.of(context).size.width;
+    final isCompact = screenWidth < 500;
 
     return Column(
       children: [
@@ -106,6 +108,8 @@ class _SmartAppBannerState extends State<SmartAppBanner> {
                     icon: const Icon(Icons.close, size: 20),
                     onPressed: () => setState(() => _isVisible = false),
                     color: theme.colorScheme.onPrimaryContainer,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
                   ),
                   const SizedBox(width: 8),
                   Container(
@@ -136,36 +140,55 @@ class _SmartAppBannerState extends State<SmartAppBanner> {
                             color: theme.colorScheme.onPrimaryContainer,
                             fontWeight: FontWeight.bold,
                           ),
-                        ),
-                        Text(
-                          l10n.openInQuizdyApp,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onPrimaryContainer
-                                .withAlpha(200),
-                          ),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
+                        if (!isCompact)
+                          Text(
+                            l10n.openInQuizdyApp,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onPrimaryContainer
+                                  .withAlpha(200),
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
                       ],
                     ),
                   ),
                   const SizedBox(width: 8),
                   if (_storeUrl.isNotEmpty) ...[
-                    OutlinedButton(
-                      onPressed: () => launchUrlString(_storeUrl),
-                      style: OutlinedButton.styleFrom(
-                        foregroundColor: theme.colorScheme.primary,
-                        side: BorderSide(color: theme.colorScheme.primary),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(20),
+                    if (isCompact)
+                      Tooltip(
+                        message: l10n.installApp,
+                        child: OutlinedButton(
+                          onPressed: () => launchUrlString(_storeUrl),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: theme.colorScheme.primary,
+                            side: BorderSide(color: theme.colorScheme.primary),
+                            shape: const CircleBorder(),
+                            padding: const EdgeInsets.all(8),
+                            minimumSize: const Size(36, 36),
+                          ),
+                          child: const Icon(Icons.download, size: 20),
                         ),
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 8,
+                      )
+                    else
+                      OutlinedButton(
+                        onPressed: () => launchUrlString(_storeUrl),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: theme.colorScheme.primary,
+                          side: BorderSide(color: theme.colorScheme.primary),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 8,
+                          ),
                         ),
+                        child: Text(l10n.installApp),
                       ),
-                      child: Text(l10n.installApp),
-                    ),
                     const SizedBox(width: 8),
                   ],
                   ElevatedButton(


### PR DESCRIPTION
This pull request enhances the responsiveness and usability of the `SmartAppBanner` widget, especially on smaller screens. The main improvements include adapting the layout for compact widths, improving button accessibility, and ensuring text does not overflow.

**Responsive layout and UI improvements:**

* Added detection of screen width and introduced an `isCompact` mode for screens narrower than 500 pixels, allowing the banner to adapt its layout for smaller devices.
* In compact mode, replaced the standard install button with a circular icon button wrapped in a `Tooltip` for better usability and space efficiency.
* Limited the app name text to a single line with ellipsis overflow to prevent layout issues on small screens.
* Hid the secondary text (`openInQuizdyApp`) in compact mode to declutter the UI on smaller devices.

**Button and interaction improvements:**

* Adjusted the close button’s padding and constraints for a more consistent and compact appearance.

Closes: https://github.com/vicajilau/quizdy/issues/398