### PR TITLE
feature: show native Android and custom update alerts

### DIFF
--- a/.github/workflows/publish_android.yml
+++ b/.github/workflows/publish_android.yml
@@ -45,5 +45,5 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.ANDROID_PLAYSTORE_ACCOUNT_KEY }}
           packageName: es.victorcarreras.quiz_app
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
-          track: internal
+          tracks: internal
           status: completed

--- a/.github/workflows/publish_android.yml
+++ b/.github/workflows/publish_android.yml
@@ -45,5 +45,5 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.ANDROID_PLAYSTORE_ACCOUNT_KEY }}
           packageName: es.victorcarreras.quiz_app
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
-          track: qa
+          track: internal
           status: completed

--- a/.github/workflows/publish_android.yml
+++ b/.github/workflows/publish_android.yml
@@ -1,8 +1,10 @@
 name: Publish Android Release
 on:
   push:
+    branches:
+      - feature/update-check
     tags:
-      - 'v*.*.*'
+      - 'v*.*.*' 
   workflow_dispatch:
 
 jobs:
@@ -43,5 +45,5 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.ANDROID_PLAYSTORE_ACCOUNT_KEY }}
           packageName: es.victorcarreras.quiz_app
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
-          track: production
+          track: qa
           status: completed

--- a/.github/workflows/publish_android.yml
+++ b/.github/workflows/publish_android.yml
@@ -1,8 +1,6 @@
 name: Publish Android Release
 on:
   push:
-    branches:
-      - feature/update-check
     tags:
       - 'v*.*.*' 
   workflow_dispatch:
@@ -45,5 +43,5 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.ANDROID_PLAYSTORE_ACCOUNT_KEY }}
           packageName: es.victorcarreras.quiz_app
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
-          tracks: internal
+          tracks: production
           status: completed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ux(quiz): Added quiz question design adjustments.
 - feat(deeplinks): Added App Links support for Android (`assetlinks.json`) and Universal Links support for iOS (`apple-app-site-association`) with pre-configured certificate fingerprints to enable seamless cross-platform deeplink testing.
 - feat(web): Enhanced web banner with automatic fallback to sample.quiz for convenient deeplink testing without manual URL parameter entry.
+- feat: Add remote version checks and in-app updates.
 
 ## [1.12.0] - 2026-04-17
 

--- a/lib/core/l10n/app_ar.arb
+++ b/lib/core/l10n/app_ar.arb
@@ -2794,5 +2794,30 @@
   },
   "openInQuizdyApp": "افتح في تطبيق Quizdy",
   "open": "افتح",
-  "installApp": "تثبيت التطبيق"
+  "installApp": "تثبيت التطبيق",
+  "updateAvailableTitle": "تحديث متاح",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "الإصدار {version} من Quizdy متاح.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "تحديث",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "التحديث مطلوب",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "مطلوب تحديث إلزامي لمتابعة استخدام Quizdy. يرجى تحديث التطبيق.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }

--- a/lib/core/l10n/app_ca.arb
+++ b/lib/core/l10n/app_ca.arb
@@ -2482,5 +2482,30 @@
   },
   "openInQuizdyApp": "Obre a l'aplicació Quizdy",
   "open": "Obre",
-  "installApp": "Instal·lar App"
+  "installApp": "Instal·lar App",
+  "updateAvailableTitle": "Actualització disponible",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "La versió {version} de Quizdy està disponible.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Actualitzar",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Actualització obligatòria",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Cal una actualització obligatòria per continuar utilitzant Quizdy. Si us plau, actualitzeu l'aplicació.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -2476,5 +2476,30 @@
   },
   "openInQuizdyApp": "In der Quizdy-App öffnen",
   "open": "Öffnen",
-  "installApp": "App installieren"
+  "installApp": "App installieren",
+  "updateAvailableTitle": "Update verfügbar",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Version {version} von Quizdy ist verfügbar.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Update",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Update erforderlich",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Ein obligatorisches Update ist erforderlich, um Quizdy weiterhin zu verwenden. Bitte aktualisieren Sie die App.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }

--- a/lib/core/l10n/app_el.arb
+++ b/lib/core/l10n/app_el.arb
@@ -1380,5 +1380,30 @@
   },
   "openInQuizdyApp": "Άνοιγμα στην εφαρμογή Quizdy",
   "open": "Άνοιγμα",
-  "installApp": "Εγκατάσταση εφαρμογής"
+  "installApp": "Εγκατάσταση εφαρμογής",
+  "updateAvailableTitle": "Διαθέσιμη ενημέρωση",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Η έκδοση {version} του Quizdy είναι διαθέσιμη.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Ενημέρωση",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Απαιτείται ενημέρωση",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Απαιτείται υποχρεωτική ενημέρωση για να συνεχίσετε να χρησιμοποιείτε το Quizdy. Παρακαλούμε ενημερώστε την εφαρμογή.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -2865,5 +2865,30 @@
   "installApp": "Install App",
   "@installApp": {
     "description": "Label for the button to install the app from the store."
+  },
+  "updateAvailableTitle": "Update available",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Version {version} of Quizdy is available.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Update",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Update required",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "A mandatory update is required to continue using Quizdy. Please update the app.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
   }
 }

--- a/lib/core/l10n/app_es.arb
+++ b/lib/core/l10n/app_es.arb
@@ -2619,5 +2619,30 @@
   },
   "openInQuizdyApp": "Abrir en la app de Quizdy",
   "open": "Abrir",
-  "installApp": "Instalar App"
+  "installApp": "Instalar App",
+  "updateAvailableTitle": "Actualización disponible",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "La versión {version} de Quizdy está disponible.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Actualizar",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Actualización requerida",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Se requiere una actualización obligatoria para continuar usando Quizdy. Por favor, actualiza la aplicación.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }

--- a/lib/core/l10n/app_eu.arb
+++ b/lib/core/l10n/app_eu.arb
@@ -2380,5 +2380,31 @@
   },
   "openInQuizdyApp": "Ireki Quizdy aplikazioan",
   "open": "Ireki",
-  "installApp": "Instalatu aplikazioa"
+  "installApp": "Instalatu aplikazioa",
+  "updateAvailableTitle": "Eguneratzea eskuragarri",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Quizdy-ren {version} bertsioa eskuragarri dago.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Eguneratu",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Eguneratzea beharrezkoa",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Derrigorrezko eguneratzea beharrezkoa da Quizdy erabiltzen jarraitzak. Mesedez, eguneratu aplikazioa.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_fr.arb
+++ b/lib/core/l10n/app_fr.arb
@@ -2425,5 +2425,31 @@
   },
   "openInQuizdyApp": "Ouvrir dans l'application Quizdy",
   "open": "Ouvrir",
-  "installApp": "Installer l'application"
+  "installApp": "Installer l'application",
+  "updateAvailableTitle": "Mise à jour disponible",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "La version {version} de Quizdy est disponible.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Mettre à jour",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Mise à jour requise",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Une mise à jour obligatoire est requise pour continuer à utiliser Quizdy. Veuillez mettre à jour l'application.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_gl.arb
+++ b/lib/core/l10n/app_gl.arb
@@ -2380,5 +2380,31 @@
   },
   "openInQuizdyApp": "Abrir na app de Quizdy",
   "open": "Abrir",
-  "installApp": "Instalar App"
+  "installApp": "Instalar App",
+  "updateAvailableTitle": "Actualización dispoñible",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "A versión {version} de Quizdy está dispoñible.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Actualizar",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Actualización requirida",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Requírese unha actualización obrigatoria para continuar usando Quizdy. Por favor, actualiza a aplicación.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_hi.arb
+++ b/lib/core/l10n/app_hi.arb
@@ -2383,5 +2383,31 @@
   },
   "openInQuizdyApp": "Quizdy ऐप में खोलें",
   "open": "खोलें",
-  "installApp": "ऐप इंस्टॉल करें"
+  "installApp": "ऐप इंस्टॉल करें",
+  "updateAvailableTitle": "अपडेट उपलब्ध है",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Quizdy का संस्करण {version} उपलब्ध है।",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "अपडेट करें",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "अपडेट आवश्यक है",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Quizdy का उपयोग जारी रखने के लिए एक अनिवार्य अपडेट आवश्यक है। कृपया ऐप अपडेट करें।",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_it.arb
+++ b/lib/core/l10n/app_it.arb
@@ -2434,5 +2434,31 @@
   },
   "openInQuizdyApp": "Apri nell'app Quizdy",
   "open": "Apri",
-  "installApp": "Installa App"
+  "installApp": "Installa App",
+  "updateAvailableTitle": "Aggiornamento disponibile",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "La versione {version} di Quizdy è disponibile.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Aggiorna",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Aggiornamento richiesto",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "È necessario un aggiornamento obbligatorio per continuare a utilizzare Quizdy. Aggiorna l'app.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_ja.arb
+++ b/lib/core/l10n/app_ja.arb
@@ -2383,5 +2383,31 @@
   },
   "openInQuizdyApp": "Quizdyアプリで開く",
   "open": "開く",
-  "installApp": "アプリをインストール"
+  "installApp": "アプリをインストール",
+  "updateAvailableTitle": "アップデートが利用可能です",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Quizdyのバージョン{version}が利用可能です。",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "アップデート",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "アップデートが必要です",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Quizdyを引き続き使用するには、強制アップデートが必要です。アプリをアップデートしてください。",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_ka.arb
+++ b/lib/core/l10n/app_ka.arb
@@ -1072,5 +1072,31 @@
   },
   "openInQuizdyApp": "გახსნა Quizdy აპში",
   "open": "გახსნა",
-  "installApp": "აპლიკაციის ინსტალაცია"
+  "installApp": "აპლიკაციის ინსტალაცია",
+  "updateAvailableTitle": "განახლება ხელმისაწვდომია",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Quizdy-ს ვერსია {version} ხელმისაწვდომია.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "განახლება",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "საჭიროა განახლება",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Quizdy-ს გამოყენების გასაგრძელებლად საჭიროა სავალდებულო განახლება. გთხოვთ, განაახლოთ აპი.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_ko.arb
+++ b/lib/core/l10n/app_ko.arb
@@ -1072,5 +1072,31 @@
   },
   "openInQuizdyApp": "Quizdy 앱에서 열기",
   "open": "열기",
-  "installApp": "앱 설치"
+  "installApp": "앱 설치",
+  "updateAvailableTitle": "업데이트 가능",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Quizdy의 {version} 버전을 사용할 수 있습니다.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "업데이트",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "업데이트 필요",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Quizdy를 계속 사용하려면 필수 업데이트가 필요합니다. 앱을 업데이트해 주세요.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_pt.arb
+++ b/lib/core/l10n/app_pt.arb
@@ -2471,5 +2471,31 @@
   },
   "openInQuizdyApp": "Abrir no app Quizdy",
   "open": "Abrir",
-  "installApp": "Instalar App"
+  "installApp": "Instalar App",
+  "updateAvailableTitle": "Atualização disponível",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "A versão {version} do Quizdy está disponível.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Atualizar",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Atualização obrigatória",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "É necessária uma atualização obrigatória para continuar a utilizar o Quizdy. Por favor, atualize a aplicação.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_ru.arb
+++ b/lib/core/l10n/app_ru.arb
@@ -1087,5 +1087,31 @@
   },
   "openInQuizdyApp": "Открыть в приложении Quizdy",
   "open": "Открыть",
-  "installApp": "Установить приложение"
+  "installApp": "Установить приложение",
+  "updateAvailableTitle": "Доступно обновление",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Доступна версия {version} приложения Quizdy.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Обновить",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Требуется обновление",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Для продолжения использования Quizdy необходимо обязательное обновление. Пожалуйста, обновите приложение.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_uk.arb
+++ b/lib/core/l10n/app_uk.arb
@@ -1105,5 +1105,31 @@
   },
   "openInQuizdyApp": "Відкрити в додатку Quizdy",
   "open": "Відкрити",
-  "installApp": "Встановити додаток"
+  "installApp": "Встановити додаток",
+  "updateAvailableTitle": "Доступне оновлення",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Доступна версія {version} Quizdy.",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "Оновити",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "Необхідне оновлення",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "Для продовження використання Quizdy необхідне обов'язкове оновлення. Будь ласка, оновіть програму.",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -2432,5 +2432,31 @@
   },
   "openInQuizdyApp": "在 Quizdy 应用中打开",
   "open": "打开",
-  "installApp": "安装应用"
+  "installApp": "安装应用",
+  "updateAvailableTitle": "有可用更新",
+  "@updateAvailableTitle": {
+    "description": "Title shown in the update banner when a newer app version is available."
+  },
+  "updateAvailableMessage": "Quizdy 版本 {version} 已发布。",
+  "@updateAvailableMessage": {
+    "description": "Subtitle in the update banner indicating which version is available.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateButton": "更新",
+  "@updateButton": {
+    "description": "Label for the update button in the update banner."
+  },
+  "forceUpdateTitle": "需要更新",
+  "@forceUpdateTitle": {
+    "description": "Title of the force update dialog."
+  },
+  "forceUpdateMessage": "需要强制更新才能继续使用 Quizdy。请更新应用。",
+  "@forceUpdateMessage": {
+    "description": "Body message of the force update dialog."
+  }
 }
+

--- a/lib/core/service_locator.dart
+++ b/lib/core/service_locator.dart
@@ -72,9 +72,8 @@ class ServiceLocator {
     );
 
     getIt.registerFactory<AppUpdateCubit>(
-      () => AppUpdateCubit(
-        remoteConfigService: getIt<AppRemoteConfigService>(),
-      ),
+      () =>
+          AppUpdateCubit(remoteConfigService: getIt<AppRemoteConfigService>()),
     );
 
     getIt.registerSingleton<AiRepositoryFactory>(

--- a/lib/core/service_locator.dart
+++ b/lib/core/service_locator.dart
@@ -22,6 +22,7 @@ import 'package:quizdy/data/services/ai/ai_document_chunking_service.dart';
 import 'package:quizdy/data/services/ai/ai_jit_processing_service.dart';
 import 'package:quizdy/data/services/ai/ai_question_generation_service.dart';
 import 'package:quizdy/data/services/app_remote_config_service.dart';
+import 'package:quizdy/presentation/blocs/app_update_cubit/app_update_cubit.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
 import 'package:quizdy/domain/use_cases/check_file_changes_use_case.dart';
 
@@ -67,6 +68,12 @@ class ServiceLocator {
       AppRemoteConfigService(
         sharedPreferences: sharedPreferences,
         dio: dioClient,
+      ),
+    );
+
+    getIt.registerFactory<AppUpdateCubit>(
+      () => AppUpdateCubit(
+        remoteConfigService: getIt<AppRemoteConfigService>(),
       ),
     );
 

--- a/lib/domain/use_cases/check_app_version_use_case.dart
+++ b/lib/domain/use_cases/check_app_version_use_case.dart
@@ -1,0 +1,77 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:quizdy/data/services/app_remote_config_service.dart';
+
+enum AppVersionStatus { upToDate, updateAvailable, forceUpdateRequired }
+
+class CheckAppVersionUseCase {
+  /// Compares [installedVersion] against the remote config.
+  ///
+  /// Returns [AppVersionStatus.forceUpdateRequired] when the installed version
+  /// is below [AppRemoteConfig.minimumSupportedVersion], and
+  /// [AppVersionStatus.updateAvailable] when a newer [AppRemoteConfig.latestVersion]
+  /// exists. Returns [AppVersionStatus.upToDate] otherwise.
+  AppVersionStatus execute({
+    required String installedVersion,
+    required AppRemoteConfig remoteConfig,
+  }) {
+    final minimumRaw = remoteConfig.minimumSupportedVersion;
+    if (minimumRaw != null) {
+      final minimum = _parseVersion(minimumRaw);
+      final installed = _parseVersion(installedVersion);
+      if (minimum != null && installed != null && installed < minimum) {
+        return AppVersionStatus.forceUpdateRequired;
+      }
+    }
+
+    final latestRaw = remoteConfig.latestVersion;
+    if (latestRaw != null) {
+      final latest = _parseVersion(latestRaw);
+      final installed = _parseVersion(installedVersion);
+      if (latest != null && installed != null && installed < latest) {
+        return AppVersionStatus.updateAvailable;
+      }
+    }
+
+    return AppVersionStatus.upToDate;
+  }
+
+  /// Parses a semantic version string such as "1.2.3" into a comparable list.
+  /// Returns `null` if the string is malformed.
+  List<int>? _parseVersion(String raw) {
+    try {
+      final cleaned = raw.trim().split('+').first;
+      final parts = cleaned.split('.').map(int.parse).toList();
+      if (parts.length < 2 || parts.length > 3) return null;
+      while (parts.length < 3) {
+        parts.add(0);
+      }
+      return parts;
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+extension on List<int> {
+  bool operator <(List<int> other) {
+    for (var i = 0; i < length && i < other.length; i++) {
+      if (this[i] < other[i]) return true;
+      if (this[i] > other[i]) return false;
+    }
+    return false;
+  }
+}

--- a/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
+++ b/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
@@ -75,8 +75,7 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
     if (PlatformDetail.isAndroid) {
       try {
         final info = await InAppUpdate.checkForUpdate();
-        if (info.updateAvailability == UpdateAvailability.updateAvailable &&
-            info.flexibleUpdateAllowed) {
+        if (info.updateAvailability == UpdateAvailability.updateAvailable) {
           await InAppUpdate.startFlexibleUpdate();
         }
       } catch (e) {
@@ -98,22 +97,10 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
     if (PlatformDetail.isAndroid) {
       try {
         final info = await InAppUpdate.checkForUpdate();
-        printInDebug(
-          '[AppUpdateCubit] checkForUpdate result: '
-          'availability=${info.updateAvailability}, '
-          'immediateAllowed=${info.immediateUpdateAllowed}, '
-          'flexibleAllowed=${info.flexibleUpdateAllowed}',
-        );
         if (info.updateAvailability == UpdateAvailability.updateAvailable) {
-          // Skip immediateUpdateAllowed — it can be false in Internal Testing
-          // even when the update is genuinely available. Let Play decide.
-          final result = await InAppUpdate.performImmediateUpdate();
-          if (result == AppUpdateResult.success) {
-            emit(const AppUpdateUpToDate());
-            return;
-          }
-          // User dismissed or update failed — fall through to ForceUpdateDialog
-          // which blocks app usage via PopScope(canPop: false).
+          await InAppUpdate.performImmediateUpdate();
+          emit(const AppUpdateUpToDate());
+          return;
         }
       } catch (e) {
         // Expected in debug/sideloaded builds — Play In-App Updates only works
@@ -123,7 +110,5 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
         );
       }
     }
-
-    emit(const AppUpdateForceRequired());
   }
 }

--- a/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
+++ b/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
@@ -83,9 +83,7 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
       } catch (e) {
         // Expected in debug/sideloaded builds — Play In-App Updates only works
         // for apps installed from the Play Store (ERROR_APP_NOT_OWNED otherwise).
-        printInDebug(
-          '[AppUpdateCubit] Android flexible update unavailable: $e',
-        );
+        printInDebug('[AppUpdateCubit] Android flexible update error: $e');
       }
       emit(const AppUpdateUpToDate());
       return;
@@ -103,19 +101,13 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
         if (info.updateAvailability == UpdateAvailability.updateAvailable ||
             info.updateAvailability ==
                 UpdateAvailability.developerTriggeredUpdateInProgress) {
-          final result = await InAppUpdate.performImmediateUpdate();
-          if (result == AppUpdateResult.success) {
-            emit(const AppUpdateUpToDate());
-            return;
-          }
+          await InAppUpdate.performImmediateUpdate();
           // User dismissed — fall through to ForceUpdateDialog
         }
       } catch (e) {
         // Expected in debug/sideloaded builds — Play In-App Updates only works
         // for apps installed from the Play Store (ERROR_APP_NOT_OWNED otherwise).
-        printInDebug(
-          '[AppUpdateCubit] Android immediate update unavailable: $e',
-        );
+        printInDebug('[AppUpdateCubit] Android immediate update error: $e');
       }
     }
 

--- a/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
+++ b/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
@@ -83,7 +83,7 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
       } catch (e) {
         // Expected in debug/sideloaded builds — Play In-App Updates only works
         // for apps installed from the Play Store (ERROR_APP_NOT_OWNED otherwise).
-        printInDebug('[AppUpdateCubit] Android flexible update error: $e');
+        printInDebug('[AppUpdateCubit] Android flexible update: $e');
       }
       emit(const AppUpdateUpToDate());
       return;
@@ -107,7 +107,7 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
       } catch (e) {
         // Expected in debug/sideloaded builds — Play In-App Updates only works
         // for apps installed from the Play Store (ERROR_APP_NOT_OWNED otherwise).
-        printInDebug('[AppUpdateCubit] Android immediate update error: $e');
+        printInDebug('[AppUpdateCubit] Android immediate update: $e');
       }
     }
 

--- a/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
+++ b/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
@@ -65,7 +65,7 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
           await handleForceUpdate();
       }
     } catch (e) {
-      printInDebug('[AppUpdateCubit] version check failed: $e');
+      printInDebug('[AppUpdateCubit] version check failed error: $e');
       emit(const AppUpdateUpToDate());
     }
   }
@@ -83,7 +83,7 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
       } catch (e) {
         // Expected in debug/sideloaded builds — Play In-App Updates only works
         // for apps installed from the Play Store (ERROR_APP_NOT_OWNED otherwise).
-        printInDebug('[AppUpdateCubit] Android flexible update: $e');
+        printInDebug('[AppUpdateCubit] Android flexible update error: $e');
       }
       emit(const AppUpdateUpToDate());
       return;

--- a/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
+++ b/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
@@ -117,7 +117,6 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
           '[AppUpdateCubit] Android immediate update unavailable: $e',
         );
       }
-      return;
     }
 
     emit(const AppUpdateForceRequired());

--- a/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
+++ b/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
@@ -98,8 +98,15 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
     if (PlatformDetail.isAndroid) {
       try {
         final info = await InAppUpdate.checkForUpdate();
-        if (info.updateAvailability == UpdateAvailability.updateAvailable &&
-            info.immediateUpdateAllowed) {
+        printInDebug(
+          '[AppUpdateCubit] checkForUpdate result: '
+          'availability=${info.updateAvailability}, '
+          'immediateAllowed=${info.immediateUpdateAllowed}, '
+          'flexibleAllowed=${info.flexibleUpdateAllowed}',
+        );
+        if (info.updateAvailability == UpdateAvailability.updateAvailable) {
+          // Skip immediateUpdateAllowed — it can be false in Internal Testing
+          // even when the update is genuinely available. Let Play decide.
           await InAppUpdate.performImmediateUpdate();
           emit(const AppUpdateUpToDate());
           return;

--- a/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
+++ b/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
@@ -75,7 +75,9 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
     if (PlatformDetail.isAndroid) {
       try {
         final info = await InAppUpdate.checkForUpdate();
-        if (info.updateAvailability == UpdateAvailability.updateAvailable) {
+        if (info.updateAvailability == UpdateAvailability.updateAvailable ||
+            info.updateAvailability ==
+                UpdateAvailability.developerTriggeredUpdateInProgress) {
           await InAppUpdate.startFlexibleUpdate();
         }
       } catch (e) {
@@ -97,10 +99,16 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
     if (PlatformDetail.isAndroid) {
       try {
         final info = await InAppUpdate.checkForUpdate();
-        if (info.updateAvailability == UpdateAvailability.updateAvailable) {
-          await InAppUpdate.performImmediateUpdate();
-          emit(const AppUpdateUpToDate());
-          return;
+
+        if (info.updateAvailability == UpdateAvailability.updateAvailable ||
+            info.updateAvailability ==
+                UpdateAvailability.developerTriggeredUpdateInProgress) {
+          final result = await InAppUpdate.performImmediateUpdate();
+          if (result == AppUpdateResult.success) {
+            emit(const AppUpdateUpToDate());
+            return;
+          }
+          // User dismissed — fall through to ForceUpdateDialog
         }
       } catch (e) {
         // Expected in debug/sideloaded builds — Play In-App Updates only works
@@ -109,6 +117,9 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
           '[AppUpdateCubit] Android immediate update unavailable: $e',
         );
       }
+      return;
     }
+
+    emit(const AppUpdateForceRequired());
   }
 }

--- a/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
+++ b/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:in_app_update/in_app_update.dart';
+import 'package:platform_detail/platform_detail.dart';
+import 'package:quizdy/core/debug_print.dart';
+import 'package:quizdy/data/services/app_remote_config_service.dart';
+import 'package:quizdy/domain/use_cases/check_app_version_use_case.dart';
+
+part 'app_update_state.dart';
+
+class AppUpdateCubit extends Cubit<AppUpdateState> {
+  final AppRemoteConfigService _remoteConfigService;
+
+  AppUpdateCubit({required AppRemoteConfigService remoteConfigService})
+    : _remoteConfigService = remoteConfigService,
+      super(const AppUpdateInitial()) {
+    checkForUpdate();
+  }
+
+  /// Fetches the remote config, compares versions and emits the appropriate
+  /// state. Must be called once the widget is mounted.
+  ///
+  /// On web, version checks are skipped and [AppUpdateUpToDate] is emitted.
+  /// On Android, the Play Store In-App Update API is used directly and this
+  /// cubit emits [AppUpdateUpToDate] regardless (the native UI handles the flow).
+  Future<void> checkForUpdate() async {
+    if (kIsWeb) {
+      emit(const AppUpdateUpToDate());
+      return;
+    }
+
+    try {
+      final remoteConfig = await _remoteConfigService.getConfig();
+      final versionDetails = await PlatformDetail.versionDetails();
+      final installedVersion = versionDetails.version;
+
+      final status = CheckAppVersionUseCase().execute(
+        installedVersion: installedVersion,
+        remoteConfig: remoteConfig,
+      );
+
+      switch (status) {
+        case AppVersionStatus.upToDate:
+          emit(const AppUpdateUpToDate());
+
+        case AppVersionStatus.updateAvailable:
+          await handleOptionalUpdate(remoteConfig.latestVersion!);
+
+        case AppVersionStatus.forceUpdateRequired:
+          await handleForceUpdate();
+      }
+    } catch (e) {
+      printInDebug('[AppUpdateCubit] version check failed: $e');
+      emit(const AppUpdateUpToDate());
+    }
+  }
+
+  @protected
+  Future<void> handleOptionalUpdate(String newVersion) async {
+    if (PlatformDetail.isAndroid) {
+      try {
+        final info = await InAppUpdate.checkForUpdate();
+        if (info.updateAvailability == UpdateAvailability.updateAvailable &&
+            info.flexibleUpdateAllowed) {
+          await InAppUpdate.startFlexibleUpdate();
+        }
+      } catch (e) {
+        // Expected in debug/sideloaded builds — Play In-App Updates only works
+        // for apps installed from the Play Store (ERROR_APP_NOT_OWNED otherwise).
+        printInDebug(
+          '[AppUpdateCubit] Android flexible update unavailable: $e',
+        );
+      }
+      emit(const AppUpdateUpToDate());
+      return;
+    }
+
+    emit(AppUpdateAvailable(newVersion));
+  }
+
+  @protected
+  Future<void> handleForceUpdate() async {
+    if (PlatformDetail.isAndroid) {
+      try {
+        final info = await InAppUpdate.checkForUpdate();
+        if (info.updateAvailability == UpdateAvailability.updateAvailable &&
+            info.immediateUpdateAllowed) {
+          await InAppUpdate.performImmediateUpdate();
+          emit(const AppUpdateUpToDate());
+          return;
+        }
+      } catch (e) {
+        // Expected in debug/sideloaded builds — Play In-App Updates only works
+        // for apps installed from the Play Store (ERROR_APP_NOT_OWNED otherwise).
+        printInDebug(
+          '[AppUpdateCubit] Android immediate update unavailable: $e',
+        );
+      }
+    }
+
+    emit(const AppUpdateForceRequired());
+  }
+}

--- a/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
+++ b/lib/presentation/blocs/app_update_cubit/app_update_cubit.dart
@@ -107,9 +107,13 @@ class AppUpdateCubit extends Cubit<AppUpdateState> {
         if (info.updateAvailability == UpdateAvailability.updateAvailable) {
           // Skip immediateUpdateAllowed — it can be false in Internal Testing
           // even when the update is genuinely available. Let Play decide.
-          await InAppUpdate.performImmediateUpdate();
-          emit(const AppUpdateUpToDate());
-          return;
+          final result = await InAppUpdate.performImmediateUpdate();
+          if (result == AppUpdateResult.success) {
+            emit(const AppUpdateUpToDate());
+            return;
+          }
+          // User dismissed or update failed — fall through to ForceUpdateDialog
+          // which blocks app usage via PopScope(canPop: false).
         }
       } catch (e) {
         // Expected in debug/sideloaded builds — Play In-App Updates only works

--- a/lib/presentation/blocs/app_update_cubit/app_update_state.dart
+++ b/lib/presentation/blocs/app_update_cubit/app_update_state.dart
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+part of 'app_update_cubit.dart';
+
+sealed class AppUpdateState {
+  const AppUpdateState();
+}
+
+/// Initial state — check not yet performed.
+final class AppUpdateInitial extends AppUpdateState {
+  const AppUpdateInitial();
+}
+
+/// The installed version is up to date.
+final class AppUpdateUpToDate extends AppUpdateState {
+  const AppUpdateUpToDate();
+}
+
+/// A newer optional version is available. Show a dismissible banner.
+final class AppUpdateAvailable extends AppUpdateState {
+  final String newVersion;
+
+  const AppUpdateAvailable(this.newVersion);
+}
+
+/// The installed version is below the minimum supported version.
+/// The user must update to continue using the app.
+final class AppUpdateForceRequired extends AppUpdateState {
+  const AppUpdateForceRequired();
+}

--- a/lib/presentation/screens/dialogs/force_update_dialog.dart
+++ b/lib/presentation/screens/dialogs/force_update_dialog.dart
@@ -34,10 +34,7 @@ class ForceUpdateDialog extends StatelessWidget {
         title: Text(l10n.forceUpdateTitle),
         content: Text(l10n.forceUpdateMessage),
         actions: [
-          QuizdyButton(
-            title: l10n.updateButton,
-            onPressed: onUpdatePressed,
-          ),
+          QuizdyButton(title: l10n.updateButton, onPressed: onUpdatePressed),
         ],
       ),
     );

--- a/lib/presentation/screens/dialogs/force_update_dialog.dart
+++ b/lib/presentation/screens/dialogs/force_update_dialog.dart
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+import 'package:quizdy/presentation/widgets/quizdy_button.dart';
+
+/// A non-dismissable dialog shown when the installed version is below the
+/// minimum supported version. The user must update to continue using the app.
+class ForceUpdateDialog extends StatelessWidget {
+  final VoidCallback onUpdatePressed;
+
+  const ForceUpdateDialog({super.key, required this.onUpdatePressed});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return PopScope(
+      canPop: false,
+      child: AlertDialog(
+        title: Text(l10n.forceUpdateTitle),
+        content: Text(l10n.forceUpdateMessage),
+        actions: [
+          QuizdyButton(
+            title: l10n.updateButton,
+            onPressed: onUpdatePressed,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -50,6 +50,10 @@ import 'package:quizdy/presentation/screens/widgets/home/home_header_widget.dart
 import 'package:quizdy/presentation/screens/widgets/home/home_drop_zone_widget.dart';
 import 'package:quizdy/presentation/screens/widgets/home/home_footer_widget.dart';
 import 'package:quizdy/presentation/screens/widgets/home/home_drag_mode_overlay.dart';
+import 'package:platform_detail/platform_detail.dart';
+import 'package:quizdy/presentation/blocs/app_update_cubit/app_update_cubit.dart';
+import 'package:quizdy/presentation/screens/dialogs/force_update_dialog.dart';
+import 'package:quizdy/presentation/widgets/app_update_banner.dart';
 import 'package:quizdy/presentation/widgets/smart_app_banner.dart';
 import 'package:quizdy/domain/use_cases/initialize_quiz_chunks_use_case.dart';
 import 'package:quizdy/data/repositories/quiz_file_repository.dart';
@@ -107,7 +111,21 @@ class _HomeScreenState extends State<HomeScreen> {
     });
   }
 
-  void _navigateByMode(BuildContext context, QuizMode mode, QuizFile quizFile) {
+  @protected
+  void openUpdateStoreUrl() {
+    final Uri url;
+    if (PlatformDetail.isIOS || PlatformDetail.isMacOS) {
+      url = Uri.parse('https://apps.apple.com/app/quiz-appl/id6758663432');
+    } else if (PlatformDetail.isWindows) {
+      url = Uri.parse('https://apps.microsoft.com/store/detail/9P77H0WRJSM2');
+    } else {
+      url = Uri.parse('https://github.com/vicajilau/quizdy/releases');
+    }
+    launchUrl(url, mode: LaunchMode.externalApplication);
+  }
+
+  @protected
+  void navigateByMode(BuildContext context, QuizMode mode, QuizFile quizFile) {
     if (mode == QuizMode.study) {
       _navigateToStudy(context, quizFile);
     } else {
@@ -448,189 +466,232 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocListener<FileBloc, FileState>(
-      listener: (context, state) async {
-        if (state is FileLoaded) {
-          setState(() => _isLoading = false);
-          if (context.currentRoute != AppRoutes.home) return;
-          final quizFile = state.quizFile;
-
-          final dropMode = _pendingDropMode;
-          _pendingDropMode = null;
-
-          final choice = dropMode ?? await ModeSelectionDialog.show(context);
-          if (!context.mounted || choice == null) return;
-          _navigateByMode(context, choice, quizFile);
-        }
-        if (state is FileReplacementRequest) {
-          if (context.currentRoute == AppRoutes.home) {
-            context.read<FileBloc>().add(ConfirmFileReplacement());
+    return BlocProvider<AppUpdateCubit>(
+      create: (context) => ServiceLocator.getIt<AppUpdateCubit>(),
+      child: BlocListener<AppUpdateCubit, AppUpdateState>(
+        listener: (context, updateState) async {
+          if (updateState is AppUpdateForceRequired && context.mounted) {
+            await showDialog<void>(
+              context: context,
+              barrierDismissible: false,
+              builder: (_) =>
+                  ForceUpdateDialog(onUpdatePressed: openUpdateStoreUrl),
+            );
           }
-        }
-        if (state is FileError && context.mounted) {
-          setState(() => _isLoading = false);
-          if (state.error is BadQuizFileException) {
-            final badFileException = state.error as BadQuizFileException;
-            context.presentSnackBar(badFileException.toString());
-          } else {
-            context.presentSnackBar(state.getDescription(context));
-          }
-        }
-        if (state is FileLoading) {
-          setState(() => _isLoading = true);
-        } else if (state is FileInitial) {
-          setState(() => _isLoading = false);
-        }
-      },
-      child: SmartAppBanner(
-        child: Scaffold(
-          body: DropTarget(
-            onDragDone: (details) {
-              if (ServiceLocator.getIt<DialogDropGuard>().isActive) {
-                setState(() {
-                  _isDragging = false;
-                  _hoveredDropMode = null;
-                });
-                return;
+        },
+        child: BlocListener<FileBloc, FileState>(
+          listener: (context, state) async {
+            if (state is FileLoaded) {
+              setState(() => _isLoading = false);
+              if (context.currentRoute != AppRoutes.home) return;
+              final quizFile = state.quizFile;
+
+              final dropMode = _pendingDropMode;
+              _pendingDropMode = null;
+
+              final choice =
+                  dropMode ?? await ModeSelectionDialog.show(context);
+              if (!context.mounted || choice == null) return;
+              navigateByMode(context, choice, quizFile);
+            }
+            if (state is FileReplacementRequest) {
+              if (context.currentRoute == AppRoutes.home) {
+                context.read<FileBloc>().add(ConfirmFileReplacement());
               }
-              if (details.files.isNotEmpty && !_isLoading) {
-                if (context.currentRoute != AppRoutes.home) return;
+            }
+            if (state is FileError && context.mounted) {
+              setState(() => _isLoading = false);
+              if (state.error is BadQuizFileException) {
+                final badFileException = state.error as BadQuizFileException;
+                context.presentSnackBar(badFileException.toString());
+              } else {
+                context.presentSnackBar(state.getDescription(context));
+              }
+            }
+            if (state is FileLoading) {
+              setState(() => _isLoading = true);
+            } else if (state is FileInitial) {
+              setState(() => _isLoading = false);
+            }
+          },
+          child: SmartAppBanner(
+            child: BlocBuilder<AppUpdateCubit, AppUpdateState>(
+              builder: (context, updateState) {
+                final scaffold = Scaffold(
+                  body: DropTarget(
+                    onDragDone: (details) {
+                      if (ServiceLocator.getIt<DialogDropGuard>().isActive) {
+                        setState(() {
+                          _isDragging = false;
+                          _hoveredDropMode = null;
+                        });
+                        return;
+                      }
+                      if (details.files.isNotEmpty && !_isLoading) {
+                        if (context.currentRoute != AppRoutes.home) return;
 
-                final firstFile = details.files.first;
-                if (firstFile.path.isNotEmpty) {
-                  if (!firstFile.name.toLowerCase().endsWith('.quiz')) {
-                    context.presentSnackBar(
-                      AppLocalizations.of(context)!.errorInvalidFile,
-                    );
-                    setState(() {
+                        final firstFile = details.files.first;
+                        if (firstFile.path.isNotEmpty) {
+                          if (!firstFile.name.toLowerCase().endsWith('.quiz')) {
+                            context.presentSnackBar(
+                              AppLocalizations.of(context)!.errorInvalidFile,
+                            );
+                            setState(() {
+                              _isDragging = false;
+                              _hoveredDropMode = null;
+                            });
+                            return;
+                          }
+                          final renderBox =
+                              context.findRenderObject() as RenderBox;
+                          _pendingDropMode = _modeFromPosition(
+                            details.localPosition,
+                            renderBox.size,
+                          );
+                          context.read<FileBloc>().add(QuizFileReset());
+                          context.read<FileBloc>().add(
+                            FileDropped(firstFile.path),
+                          );
+                        }
+                      }
+                      setState(() {
+                        _isDragging = false;
+                        _hoveredDropMode = null;
+                      });
+                    },
+                    onDragEntered: (_) {
+                      if (!ServiceLocator.getIt<DialogDropGuard>().isActive) {
+                        setState(() => _isDragging = true);
+                      }
+                    },
+                    onDragUpdated: (details) {
+                      if (!_isDragging) return;
+                      final renderBox = context.findRenderObject() as RenderBox;
+                      final mode = _modeFromPosition(
+                        details.localPosition,
+                        renderBox.size,
+                      );
+                      if (mode != _hoveredDropMode) {
+                        setState(() => _hoveredDropMode = mode);
+                      }
+                    },
+                    onDragExited: (_) => setState(() {
                       _isDragging = false;
                       _hoveredDropMode = null;
-                    });
-                    return;
-                  }
-                  final renderBox = context.findRenderObject() as RenderBox;
-                  _pendingDropMode = _modeFromPosition(
-                    details.localPosition,
-                    renderBox.size,
-                  );
-                  context.read<FileBloc>().add(QuizFileReset());
-                  context.read<FileBloc>().add(FileDropped(firstFile.path));
-                }
-              }
-              setState(() {
-                _isDragging = false;
-                _hoveredDropMode = null;
-              });
-            },
-            onDragEntered: (_) {
-              if (!ServiceLocator.getIt<DialogDropGuard>().isActive) {
-                setState(() => _isDragging = true);
-              }
-            },
-            onDragUpdated: (details) {
-              if (!_isDragging) return;
-              final renderBox = context.findRenderObject() as RenderBox;
-              final mode = _modeFromPosition(
-                details.localPosition,
-                renderBox.size,
-              );
-              if (mode != _hoveredDropMode) {
-                setState(() => _hoveredDropMode = mode);
-              }
-            },
-            onDragExited: (_) => setState(() {
-              _isDragging = false;
-              _hoveredDropMode = null;
-            }),
-            child: Stack(
-              children: [
-                SafeArea(
-                  child: LayoutBuilder(
-                    builder: (context, constraints) {
-                      final isMobile = context.isMobile;
-                      // Calculate the visual top margin:
-                      // SafeArea (padding.top) + Header centering offset ((72 - 48) / 2 = 12)
-                      final topPadding = MediaQuery.of(context).padding.top;
-                      final visualTopMargin = topPadding + 12.0;
+                    }),
+                    child: Stack(
+                      children: [
+                        SafeArea(
+                          child: LayoutBuilder(
+                            builder: (context, constraints) {
+                              final isMobile = context.isMobile;
+                              // Calculate the visual top margin:
+                              // SafeArea (padding.top) + Header centering offset ((72 - 48) / 2 = 12)
+                              final topPadding = MediaQuery.of(
+                                context,
+                              ).padding.top;
+                              final visualTopMargin = topPadding + 12.0;
 
-                      return SingleChildScrollView(
-                        child: ConstrainedBox(
-                          constraints: BoxConstraints(
-                            minHeight: constraints.maxHeight,
-                          ),
-                          child: IntrinsicHeight(
-                            child: Padding(
-                              padding: EdgeInsets.symmetric(
-                                horizontal: isMobile ? visualTopMargin : 48.0,
-                              ),
-                              child: Column(
-                                children: [
-                                  HomeHeaderWidget(
-                                    isLoading: _isLoading,
-                                    onSettingsTap: () =>
-                                        _showSettingsDialog(context),
+                              return SingleChildScrollView(
+                                child: ConstrainedBox(
+                                  constraints: BoxConstraints(
+                                    minHeight: constraints.maxHeight,
                                   ),
-                                  Expanded(
-                                    child: HomeDropZoneWidget(
-                                      isDragging: _isDragging,
-                                      onTap: () => _pickFile(context),
+                                  child: IntrinsicHeight(
+                                    child: Padding(
+                                      padding: EdgeInsets.symmetric(
+                                        horizontal: isMobile
+                                            ? visualTopMargin
+                                            : 48.0,
+                                      ),
+                                      child: Column(
+                                        children: [
+                                          HomeHeaderWidget(
+                                            isLoading: _isLoading,
+                                            onSettingsTap: () =>
+                                                _showSettingsDialog(context),
+                                          ),
+                                          Expanded(
+                                            child: HomeDropZoneWidget(
+                                              isDragging: _isDragging,
+                                              onTap: () => _pickFile(context),
+                                            ),
+                                          ),
+                                          HomeFooterWidget(
+                                            isLoading: _isLoading,
+                                            showFeedbackBanner:
+                                                _showFeedbackBanner,
+                                            onCreateTap: () =>
+                                                _showCreateQuizFileDialog(
+                                                  context,
+                                                ),
+                                            onGenerateAITap: () =>
+                                                _generateQuestionsWithAI(
+                                                  context,
+                                                ),
+                                            onStudyModeTap: () =>
+                                                _startStudyModeWithAI(context),
+                                            onFeedbackTap: () =>
+                                                _openFeedbackForm(context),
+                                          ),
+                                        ],
+                                      ),
                                     ),
                                   ),
-                                  HomeFooterWidget(
-                                    isLoading: _isLoading,
-                                    showFeedbackBanner: _showFeedbackBanner,
-                                    onCreateTap: () =>
-                                        _showCreateQuizFileDialog(context),
-                                    onGenerateAITap: () =>
-                                        _generateQuestionsWithAI(context),
-                                    onStudyModeTap: () =>
-                                        _startStudyModeWithAI(context),
-                                    onFeedbackTap: () =>
-                                        _openFeedbackForm(context),
-                                  ),
-                                ],
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                        if (_isDragging)
+                          Positioned.fill(
+                            child: HomeDragModeOverlay(
+                              hoveredMode: _hoveredDropMode,
+                            ),
+                          ),
+                        if (_isLoading)
+                          Positioned.fill(
+                            child: Container(
+                              color: Colors.black.withValues(alpha: 0.3),
+                              child: Center(
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const QuizdyLoading(),
+                                    if (_loadingText != null) ...[
+                                      const SizedBox(height: 16),
+                                      Material(
+                                        color: Colors.transparent,
+                                        child: Text(
+                                          _loadingText!,
+                                          style: const TextStyle(
+                                            color: Colors.white,
+                                            fontSize: 14,
+                                            fontWeight: FontWeight.w500,
+                                          ),
+                                          textAlign: TextAlign.center,
+                                        ),
+                                      ),
+                                    ],
+                                  ],
+                                ),
                               ),
                             ),
                           ),
-                        ),
-                      );
-                    },
-                  ),
-                ),
-                if (_isDragging)
-                  Positioned.fill(
-                    child: HomeDragModeOverlay(hoveredMode: _hoveredDropMode),
-                  ),
-                if (_isLoading)
-                  Positioned.fill(
-                    child: Container(
-                      color: Colors.black.withValues(alpha: 0.3),
-                      child: Center(
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const QuizdyLoading(),
-                            if (_loadingText != null) ...[
-                              const SizedBox(height: 16),
-                              Material(
-                                color: Colors.transparent,
-                                child: Text(
-                                  _loadingText!,
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.w500,
-                                  ),
-                                  textAlign: TextAlign.center,
-                                ),
-                              ),
-                            ],
-                          ],
-                        ),
-                      ),
+                      ],
                     ),
                   ),
-              ],
+                );
+
+                if (updateState is AppUpdateAvailable) {
+                  return AppUpdateBanner(
+                    newVersion: updateState.newVersion,
+                    onUpdatePressed: openUpdateStoreUrl,
+                    child: scaffold,
+                  );
+                }
+                return scaffold;
+              },
             ),
           ),
         ),

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -50,7 +50,6 @@ import 'package:quizdy/presentation/screens/widgets/home/home_header_widget.dart
 import 'package:quizdy/presentation/screens/widgets/home/home_drop_zone_widget.dart';
 import 'package:quizdy/presentation/screens/widgets/home/home_footer_widget.dart';
 import 'package:quizdy/presentation/screens/widgets/home/home_drag_mode_overlay.dart';
-import 'package:platform_detail/platform_detail.dart';
 import 'package:quizdy/presentation/blocs/app_update_cubit/app_update_cubit.dart';
 import 'package:quizdy/presentation/screens/dialogs/force_update_dialog.dart';
 import 'package:quizdy/presentation/widgets/app_update_banner.dart';
@@ -114,12 +113,23 @@ class _HomeScreenState extends State<HomeScreen> {
   @protected
   void openUpdateStoreUrl() {
     final Uri url;
-    if (PlatformDetail.isIOS || PlatformDetail.isMacOS) {
-      url = Uri.parse('https://apps.apple.com/app/quiz-appl/id6758663432');
-    } else if (PlatformDetail.isWindows) {
-      url = Uri.parse('https://apps.microsoft.com/store/detail/9P77H0WRJSM2');
-    } else {
-      url = Uri.parse('https://github.com/vicajilau/quizdy/releases');
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        url = Uri.parse('https://apps.apple.com/app/quiz-appl/id6758663432');
+        break;
+      case TargetPlatform.android:
+        url = Uri.parse(
+          'https://play.google.com/store/apps/details?id=es.victorcarreras.quiz_app',
+        );
+        break;
+      case TargetPlatform.windows:
+        url = Uri.parse('https://apps.microsoft.com/store/detail/9P77H0WRJSM2');
+        break;
+      case TargetPlatform.linux:
+        url = Uri.parse('https://snapcraft.io/quiz-app');
+      default:
+        url = Uri.parse('https://github.com/vicajilau/quizdy/releases');
     }
     launchUrl(url, mode: LaunchMode.externalApplication);
   }

--- a/lib/presentation/widgets/app_update_banner.dart
+++ b/lib/presentation/widgets/app_update_banner.dart
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+
+/// A dismissible banner that informs the user a newer version is available.
+/// Shown on non-Android platforms (Android uses the native In-App Update flow).
+class AppUpdateBanner extends StatefulWidget {
+  final Widget child;
+  final String newVersion;
+  final VoidCallback onUpdatePressed;
+
+  const AppUpdateBanner({
+    super.key,
+    required this.child,
+    required this.newVersion,
+    required this.onUpdatePressed,
+  });
+
+  @override
+  State<AppUpdateBanner> createState() => _AppUpdateBannerState();
+}
+
+class _AppUpdateBannerState extends State<AppUpdateBanner> {
+  bool _isVisible = true;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isVisible) {
+      return widget.child;
+    }
+
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    return Column(
+      children: [
+        Material(
+          color: theme.colorScheme.secondaryContainer,
+          elevation: 2,
+          child: SafeArea(
+            bottom: false,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 8.0,
+                vertical: 8.0,
+              ),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 20),
+                    onPressed: () => setState(() => _isVisible = false),
+                    color: theme.colorScheme.onPrimary,
+                  ),
+                  const SizedBox(width: 8),
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.secondary,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: SvgPicture.asset(
+                        'images/pictorial_mark.svg',
+                        width: 40,
+                        height: 40,
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l10n.updateAvailableTitle,
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            color: theme.colorScheme.onPrimary,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          l10n.updateAvailableMessage(widget.newVersion),
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onPrimary.withAlpha(200),
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: widget.onUpdatePressed,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: theme.colorScheme.secondary,
+                      foregroundColor: theme.colorScheme.onPrimary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 8,
+                      ),
+                    ),
+                    child: Text(l10n.updateButton),
+                  ),
+                  const SizedBox(width: 8),
+                ],
+              ),
+            ),
+          ),
+        ),
+        Expanded(child: widget.child),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -469,6 +469,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  in_app_update:
+    dependency: "direct main"
+    description:
+      name: in_app_update
+      sha256: "9924a3efe592e1c0ec89dda3683b3cfec3d4cd02d908e6de00c24b759038ddb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.5"
   intl:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.2+38
+version: 1.13.0+38
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.1+31
+version: 0.2.2+32
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.1+29
+version: 1.10.0+29
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.0+30
+version: 0.2.1+31
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.3+33
+version: 0.2.4+34
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.1+28
+version: 0.1.1+29
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.13.0+28
+version: 0.1.0+28
 
 environment:
   sdk: ^3.8.1
@@ -65,6 +65,7 @@ dependencies:
   pdfrx: ^2.2.24
   share_plus: ^12.0.2
   app_links: ^7.0.0
+  in_app_update: ^4.2.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.0+28
+version: 0.1.1+28
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.4+34
+version: 0.2.5+35
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.10.0+30
+version: 0.2.0+30
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.10.0+29
+version: 1.10.0+30
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+36
+version: 1.1.1+37
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.5+35
+version: 1.1.0+36
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.1+37
+version: 1.1.2+38
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.2+32
+version: 0.2.3+33
 
 environment:
   sdk: ^3.8.1

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -509,6 +509,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  in_app_update:
+    dependency: transitive
+    description:
+      name: in_app_update
+      sha256: "9924a3efe592e1c0ec89dda3683b3cfec3d4cd02d908e6de00c24b759038ddb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.5"
   inspector:
     dependency: transitive
     description:
@@ -883,7 +891,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.13.0+28"
+    version: "0.12.0+28"
   resizable_widget:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary    
                                                                                                                                                                                                                             
  Implements remote version control and in-app update flows as described in issue #392.                                                                                                                                      
                                                                                                                                                                                                                             
  ### What was added                                                                                                                                                                                                         
                                                                                                                                                                                                                             
  - **`CheckAppVersionUseCase`** — pure Dart logic that compares the installed semantic version against `latestVersion` and `minimumSupportedVersion` from the remote config, returning one of three statuses: `upToDate`,   
  `updateAvailable`, or `forceUpdateRequired`.                                                                                                                                                                               
                                                                                                                                                                                                                             
  - **`AppUpdateCubit` + `AppUpdateState`** — Cubit that orchestrates the full update flow. Fetches the remote config, runs the version check, and emits the appropriate state:                                              
    - `AppUpdateUpToDate` — no action needed                                                                                                                                                                                 
    - `AppUpdateAvailable(newVersion)` — optional update available                                                                                                                                                           
    - `AppUpdateForceRequired` — user must update to continue                                                                                                                                                                
                                                                                                                                                                                                                             
  - **`AppUpdateBanner`** — dismissible banner (adapted from `SmartAppBanner`) shown on non-Android platforms when an optional update is available. Displays the new version number and an "Update" button that opens the    
  relevant store (App Store / Microsoft Store / GitHub Releases).                                                                                                                                                            
                                                                                                                                                                                                                             
  - **`ForceUpdateDialog`** — non-dismissable dialog (`PopScope(canPop: false)`) shown as fallback when a forced update cannot be handled natively. Blocks app usage until the user taps "Update".                           
                                                                                                                                                                                                                             
  ### Platform behaviour                                                                                                                                                                                                     
                                                                                                                                                                                                                             
  | Platform | Optional update | Force update |                                                                                                                                                                              
  |---|---|---|                                                                                                                                                                                                              
  | **Web** | Skipped | Skipped |                                                                                                                                                                                            
  | **Android** | `startFlexibleUpdate()` (native Play UI) | `performImmediateUpdate()` (native Play UI). If dismissed or unavailable → `ForceUpdateDialog` |                                                                
  | **iOS / macOS** | `AppUpdateBanner` → App Store | `ForceUpdateDialog` → App Store |                                                                                                                                      
  | **Windows** | `AppUpdateBanner` → Microsoft Store | `ForceUpdateDialog` → Microsoft Store |                                                                                                                              
  | **Linux** | `AppUpdateBanner` → GitHub Releases | `ForceUpdateDialog` → GitHub Releases |                                                                                                                                
                                                                                                                                                                                                                             
  ### Dependencies                                                                                                                                                                                                           
                                                                                                                                                                                                                             
  - Added `in_app_update: ^4.2.3` for Android In-App Updates API.                                                                                                                                                            
                                                                                                                                                                                                                             
  ### Localisation                                                                                                                                                                                                           
                                                                                                                                                                                                                             
  Added five new keys to all locale ARB files: `updateAvailableTitle`, `updateAvailableMessage`, `updateButton`, `forceUpdateTitle`, `forceUpdateMessage`. 
  
  Fixes: #392