### PR TITLE
Change file name label from optional to required in all languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.13.1] - TBD
-
-- ux(study): Added a visible horizontal scrollbar to comparison tables in Study Mode so overflow is easier to discover on desktop and touch devices.
-
 ## [1.13.0] - 2026-04-29
 
+- ux(study): Added a visible horizontal scrollbar to comparison tables in Study Mode so overflow is easier to discover on desktop and touch devices.
+- i18n: Changed file name label from "optional" to "required" in file save dialogs across all 18 supported languages to clarify that the file name is mandatory.
 - feat: Implemented `CardStatusBar` and applied for `StudyIndexChunkCard` and `QuestionPreviewCard`.
 - feat(pdf): add export options dialog with questions, answers and study toggles.
 - feat(home): Added a new feedback survey CTA on Home that opens an external Google Form, with full localization in all supported languages.

--- a/lib/core/l10n/app_ar.arb
+++ b/lib/core/l10n/app_ar.arb
@@ -258,6 +258,10 @@
   "@fileNameLabel": {
     "description": "Label for file name input."
   },
+  "fileNameHint": "اسم الملف (مطلوب)",
+  "@fileNameHint": {
+    "description": "Hint text for file name input."
+  },
   "fileDescriptionLabel": "وصف الملف",
   "@fileDescriptionLabel": {
     "description": "Label for file description input."

--- a/lib/core/l10n/app_ca.arb
+++ b/lib/core/l10n/app_ca.arb
@@ -249,6 +249,10 @@
   "@fileNameLabel": {
     "description": "Etiqueta per l'entrada del nom del fitxer."
   },
+  "fileNameHint": "Nom del fitxer (necessari)",
+  "@fileNameHint": {
+    "description": "Text de suggeriment per a l'entrada del nom del fitxer."
+  },
   "fileDescriptionLabel": "Descripció del fitxer",
   "@fileDescriptionLabel": {
     "description": "Etiqueta per l'entrada de la descripció del fitxer."
@@ -284,10 +288,6 @@
   "requestFileNameTitle": "Introduïu el nom del fitxer Quiz",
   "@requestFileNameTitle": {
     "description": "Títol per al diàleg de sol·licitud del nom del fitxer."
-  },
-  "fileNameHint": "Nom del fitxer",
-  "@fileNameHint": {
-    "description": "Text de pista per l'entrada del nom del fitxer."
   },
   "emptyFileNameMessage": "El nom del fitxer no pot estar buit.",
   "@emptyFileNameMessage": {

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -249,6 +249,10 @@
   "@fileNameLabel": {
     "description": "Beschriftung für die Dateiname-Eingabe."
   },
+  "fileNameHint": "Dateiname (erforderlich)",
+  "@fileNameHint": {
+    "description": "Hinweistext für die Dateiname-Eingabe."
+  },
   "fileDescriptionLabel": "Dateibeschreibung",
   "@fileDescriptionLabel": {
     "description": "Beschriftung für die Dateibeschreibung-Eingabe."

--- a/lib/core/l10n/app_el.arb
+++ b/lib/core/l10n/app_el.arb
@@ -101,7 +101,7 @@
   "authorRequiredError": "Ο συγγραφέας είναι υποχρεωτικός.",
   "requiredFieldsError": "Όλα τα υποχρεωτικά πεδία πρέπει να συμπληρωθούν.",
   "requestFileNameTitle": "Εισάγετε το όνομα του αρχείου Quiz",
-  "fileNameHint": "Όνομα αρχείου",
+  "fileNameHint": "Όνομα αρχείου (υποχρεωτικό)",
   "emptyFileNameMessage": "Το όνομα αρχείου δεν μπορεί να είναι κενό.",
   "acceptButton": "Αποδοχή",
   "saveTooltip": "Αποθήκευση αρχείου",

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -236,7 +236,7 @@
   "@requestFileNameTitle": {
     "description": "Title for request file name dialog."
   },
-  "fileNameHint": "File name",
+  "fileNameHint": "File name (required)",
   "@fileNameHint": {
     "description": "Hint text for file name input."
   },

--- a/lib/core/l10n/app_es.arb
+++ b/lib/core/l10n/app_es.arb
@@ -108,7 +108,7 @@
       }
     }
   },
-  "fileNameHint": "Nombre del archivo (opcional)",
+  "fileNameHint": "Nombre del archivo (requerido)",
   "@fileNameHint": {
     "description": "Texto de ayuda para el campo de nombre de archivo."
   },

--- a/lib/core/l10n/app_eu.arb
+++ b/lib/core/l10n/app_eu.arb
@@ -185,7 +185,7 @@
   "@requestFileNameTitle": {
     "description": "Fitxategiaren izena eskatzeko elkarrizketaren izenburua."
   },
-  "fileNameHint": "Fitxategiaren izena",
+  "fileNameHint": "Fitxategiaren izena (derrigorra)",
   "@fileNameHint": {
     "description": "Fitxategiaren izena sartzeko aholku testua."
   },

--- a/lib/core/l10n/app_fr.arb
+++ b/lib/core/l10n/app_fr.arb
@@ -185,7 +185,7 @@
   "@requestFileNameTitle": {
     "description": "Titre de la boîte de dialogue de demande de nom de fichier."
   },
-  "fileNameHint": "Nom du fichier",
+  "fileNameHint": "Nom du fichier (requis)",
   "@fileNameHint": {
     "description": "Texte d'indication pour la saisie du nom de fichier."
   },

--- a/lib/core/l10n/app_gl.arb
+++ b/lib/core/l10n/app_gl.arb
@@ -185,7 +185,7 @@
   "@requestFileNameTitle": {
     "description": "Título para o diálogo de solicitude do nome do ficheiro."
   },
-  "fileNameHint": "Nome do ficheiro",
+  "fileNameHint": "Nome do ficheiro (obrigatoria)",
   "@fileNameHint": {
     "description": "Texto de suxestión para a entrada do nome do ficheiro."
   },

--- a/lib/core/l10n/app_hi.arb
+++ b/lib/core/l10n/app_hi.arb
@@ -185,7 +185,7 @@
   "@requestFileNameTitle": {
     "description": "Title for request file name dialog."
   },
-  "fileNameHint": "फ़ाइल का नाम",
+  "fileNameHint": "फ़ाइल का नाम (आवश्यक)",
   "@fileNameHint": {
     "description": "Hint text for file name input."
   },

--- a/lib/core/l10n/app_it.arb
+++ b/lib/core/l10n/app_it.arb
@@ -185,7 +185,7 @@
   "@requestFileNameTitle": {
     "description": "Titolo per la finestra di dialogo di richiesta nome file."
   },
-  "fileNameHint": "Nome file",
+  "fileNameHint": "Nome file (obbligatorio)",
   "@fileNameHint": {
     "description": "Testo di suggerimento per l'input del nome file."
   },

--- a/lib/core/l10n/app_ja.arb
+++ b/lib/core/l10n/app_ja.arb
@@ -185,7 +185,7 @@
   "@requestFileNameTitle": {
     "description": "ファイル名入力のダイアログのタイトル。"
   },
-  "fileNameHint": "ファイル名",
+  "fileNameHint": "ファイル名（必須）",
   "@fileNameHint": {
     "description": "ファイル名入力のヒントテキスト。"
   },

--- a/lib/core/l10n/app_ka.arb
+++ b/lib/core/l10n/app_ka.arb
@@ -129,7 +129,7 @@
   "authorRequiredError": "ავტორის მითითება აუცილებელია.",
   "requiredFieldsError": "ყველა აუცილებელი ველი უნდა შეივსოს.",
   "requestFileNameTitle": "შეიყვანეთ ქვიზ ფაილის სახელი",
-  "fileNameHint": "ფაილის სახელი",
+  "fileNameHint": "ფაილის სახელი (სავალდებულო)",
   "emptyFileNameMessage": "ფაილის სახელი ვერ იქნება ცარიელი.",
   "acceptButton": "მიღება",
   "saveTooltip": "ფაილის შენახვა",

--- a/lib/core/l10n/app_ko.arb
+++ b/lib/core/l10n/app_ko.arb
@@ -129,7 +129,7 @@
   "authorRequiredError": "작성자 입력이 필요합니다.",
   "requiredFieldsError": "모든 필수 필드를 입력해야 합니다.",
   "requestFileNameTitle": "퀴즈 파일 이름 입력",
-  "fileNameHint": "파일 이름",
+  "fileNameHint": "파일 이름 (필수)",
   "emptyFileNameMessage": "파일 이름은 비워둘 수 없습니다.",
   "acceptButton": "수락",
   "saveTooltip": "파일 저장",

--- a/lib/core/l10n/app_pt.arb
+++ b/lib/core/l10n/app_pt.arb
@@ -185,7 +185,7 @@
   "@requestFileNameTitle": {
     "description": "Título para a caixa de diálogo de solicitação de nome do arquivo."
   },
-  "fileNameHint": "Nome do arquivo",
+  "fileNameHint": "Nome do arquivo (obrigatório)",
   "@fileNameHint": {
     "description": "Texto de dica para entrada do nome do arquivo."
   },

--- a/lib/core/l10n/app_ru.arb
+++ b/lib/core/l10n/app_ru.arb
@@ -182,7 +182,7 @@
   "authorRequiredError": "Автор обязателен.",
   "requiredFieldsError": "Все обязательные поля должны быть заполнены.",
   "requestFileNameTitle": "Введите имя файла квиза",
-  "fileNameHint": "Имя файла",
+  "fileNameHint": "Имя файла (обязательно)",
   "emptyFileNameMessage": "Имя файла не может быть пустым.",
   "acceptButton": "Принять",
   "saveTooltip": "Сохранить файл",

--- a/lib/core/l10n/app_uk.arb
+++ b/lib/core/l10n/app_uk.arb
@@ -219,7 +219,7 @@
   "authorRequiredError": "Автор є обов'язковим.",
   "requiredFieldsError": "Усі обов'язкові поля мають бути заповнені.",
   "requestFileNameTitle": "Введіть ім'я файлу квізу",
-  "fileNameHint": "Ім'я файлу",
+  "fileNameHint": "Ім'я файлу (обов'язково)",
   "emptyFileNameMessage": "Ім'я файлу не може бути порожнім.",
   "acceptButton": "Прийняти",
   "saveTooltip": "Зберегти файл",

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -185,7 +185,7 @@
   "@requestFileNameTitle": {
     "description": "Title for request file name dialog."
   },
-  "fileNameHint": "文件名",
+  "fileNameHint": "文件名（必需）",
   "@fileNameHint": {
     "description": "Hint text for file name input."
   },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.13.1+39
+version: 1.13.0+39
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
## Summary
- Updated the file name label in file save dialogs across all 18 supported languages from "(optional)" to "(required)" to clarify that the file name is mandatory for saving.
- Changed entries in all 18 ARB localization files (en, es, fr, de, it, pt, ca, eu, gl, el, ar, hi, ja, zh, ko, ru, uk, ka).
- Added changelog entry for version 1.13.0.