### PR TITLE
fix(statusbar): status bar repaint while update banner visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.13.1] - TBD
 
-- fix(home): Status bar icons now switch to white while the update banner is visible on Home, and automatically restore theme-based light/dark colors when the banner is dismissed.
+- fix(mobile): Status bar icons now switch to white while the update banner is visible in light mode, and automatically restore theme-based light/dark colors when the banner is dismissed.
+- fix(mobile): Improved readability of the system status bar during in-app update prompts, dynamically adjusting icon colors to ensure they remain clearly visible over the update banner and seamlessly restore to their native theme once dismissed.
 
 ## [1.13.0] - 2026-04-29
 - ux(study): Added a visible horizontal scrollbar to comparison tables in Study Mode so overflow is easier to discover on desktop and touch devices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.13.1] - TBD
 
-- fix(mobile): Status bar icons now switch to white while the update banner is visible in light mode, and automatically restore theme-based light/dark colors when the banner is dismissed.
 - fix(mobile): Improved readability of the system status bar during in-app update prompts, dynamically adjusting icon colors to ensure they remain clearly visible over the update banner and seamlessly restore to their native theme once dismissed.
 
 ## [1.13.0] - 2026-04-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.13.0] - 2026-04-29
+## [1.13.1] - TBD
 
+- fix(home): Status bar icons now switch to white while the update banner is visible on Home, and automatically restore theme-based light/dark colors when the banner is dismissed.
+
+## [1.13.0] - 2026-04-29
 - ux(study): Added a visible horizontal scrollbar to comparison tables in Study Mode so overflow is easier to discover on desktop and touch devices.
 - i18n: Changed file name label from "optional" to "required" in file save dialogs across all 18 supported languages to clarify that the file name is mandatory.
 - feat: Implemented `CardStatusBar` and applied for `StudyIndexChunkCard` and `QuestionPreviewCard`.

--- a/app_config.json
+++ b/app_config.json
@@ -1,6 +1,6 @@
 {
   "homeFeedbackEnabled": true,
   "homeFeedbackUrl": "https://docs.google.com/forms/d/e/1FAIpQLSd3NmQZyROb7Z_tnULmbJuBEJpOW02_EjcIRNBRVLsKF7lFHQ/viewform?usp=publish-editor",
-  "latestVersion": "1.13.0",
+  "latestVersion": "1.15.0",
   "minimumSupportedVersion": "1.0.0"
 }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -16,6 +16,7 @@
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -527,168 +528,192 @@ class _HomeScreenState extends State<HomeScreen> {
           child: SmartAppBanner(
             child: BlocBuilder<AppUpdateCubit, AppUpdateState>(
               builder: (context, updateState) {
-                final scaffold = Scaffold(
-                  body: DropTarget(
-                    onDragDone: (details) {
-                      if (ServiceLocator.getIt<DialogDropGuard>().isActive) {
+                final isDarkMode =
+                    Theme.of(context).brightness == Brightness.dark;
+                final scaffold = AnnotatedRegion<SystemUiOverlayStyle>(
+                  value: SystemUiOverlayStyle(
+                    statusBarColor: Colors.transparent,
+                    statusBarIconBrightness: isDarkMode
+                        ? Brightness.light
+                        : Brightness.dark,
+                    statusBarBrightness: isDarkMode
+                        ? Brightness.dark
+                        : Brightness.light,
+                    systemNavigationBarColor: Theme.of(
+                      context,
+                    ).scaffoldBackgroundColor,
+                    systemNavigationBarIconBrightness: isDarkMode
+                        ? Brightness.light
+                        : Brightness.dark,
+                  ),
+                  child: Scaffold(
+                    body: DropTarget(
+                      onDragDone: (details) {
+                        if (ServiceLocator.getIt<DialogDropGuard>().isActive) {
+                          setState(() {
+                            _isDragging = false;
+                            _hoveredDropMode = null;
+                          });
+                          return;
+                        }
+                        if (details.files.isNotEmpty && !_isLoading) {
+                          if (context.currentRoute != AppRoutes.home) return;
+
+                          final firstFile = details.files.first;
+                          if (firstFile.path.isNotEmpty) {
+                            if (!firstFile.name.toLowerCase().endsWith(
+                              '.quiz',
+                            )) {
+                              context.presentSnackBar(
+                                AppLocalizations.of(context)!.errorInvalidFile,
+                              );
+                              setState(() {
+                                _isDragging = false;
+                                _hoveredDropMode = null;
+                              });
+                              return;
+                            }
+                            final renderBox =
+                                context.findRenderObject() as RenderBox;
+                            _pendingDropMode = _modeFromPosition(
+                              details.localPosition,
+                              renderBox.size,
+                            );
+                            context.read<FileBloc>().add(QuizFileReset());
+                            context.read<FileBloc>().add(
+                              FileDropped(firstFile.path),
+                            );
+                          }
+                        }
                         setState(() {
                           _isDragging = false;
                           _hoveredDropMode = null;
                         });
-                        return;
-                      }
-                      if (details.files.isNotEmpty && !_isLoading) {
-                        if (context.currentRoute != AppRoutes.home) return;
-
-                        final firstFile = details.files.first;
-                        if (firstFile.path.isNotEmpty) {
-                          if (!firstFile.name.toLowerCase().endsWith('.quiz')) {
-                            context.presentSnackBar(
-                              AppLocalizations.of(context)!.errorInvalidFile,
-                            );
-                            setState(() {
-                              _isDragging = false;
-                              _hoveredDropMode = null;
-                            });
-                            return;
-                          }
-                          final renderBox =
-                              context.findRenderObject() as RenderBox;
-                          _pendingDropMode = _modeFromPosition(
-                            details.localPosition,
-                            renderBox.size,
-                          );
-                          context.read<FileBloc>().add(QuizFileReset());
-                          context.read<FileBloc>().add(
-                            FileDropped(firstFile.path),
-                          );
+                      },
+                      onDragEntered: (_) {
+                        if (!ServiceLocator.getIt<DialogDropGuard>().isActive) {
+                          setState(() => _isDragging = true);
                         }
-                      }
-                      setState(() {
+                      },
+                      onDragUpdated: (details) {
+                        if (!_isDragging) return;
+                        final renderBox =
+                            context.findRenderObject() as RenderBox;
+                        final mode = _modeFromPosition(
+                          details.localPosition,
+                          renderBox.size,
+                        );
+                        if (mode != _hoveredDropMode) {
+                          setState(() => _hoveredDropMode = mode);
+                        }
+                      },
+                      onDragExited: (_) => setState(() {
                         _isDragging = false;
                         _hoveredDropMode = null;
-                      });
-                    },
-                    onDragEntered: (_) {
-                      if (!ServiceLocator.getIt<DialogDropGuard>().isActive) {
-                        setState(() => _isDragging = true);
-                      }
-                    },
-                    onDragUpdated: (details) {
-                      if (!_isDragging) return;
-                      final renderBox = context.findRenderObject() as RenderBox;
-                      final mode = _modeFromPosition(
-                        details.localPosition,
-                        renderBox.size,
-                      );
-                      if (mode != _hoveredDropMode) {
-                        setState(() => _hoveredDropMode = mode);
-                      }
-                    },
-                    onDragExited: (_) => setState(() {
-                      _isDragging = false;
-                      _hoveredDropMode = null;
-                    }),
-                    child: Stack(
-                      children: [
-                        SafeArea(
-                          child: LayoutBuilder(
-                            builder: (context, constraints) {
-                              final isMobile = context.isMobile;
-                              // Calculate the visual top margin:
-                              // SafeArea (padding.top) + Header centering offset ((72 - 48) / 2 = 12)
-                              final topPadding = MediaQuery.of(
-                                context,
-                              ).padding.top;
-                              final visualTopMargin = topPadding + 12.0;
+                      }),
+                      child: Stack(
+                        children: [
+                          SafeArea(
+                            child: LayoutBuilder(
+                              builder: (context, constraints) {
+                                final isMobile = context.isMobile;
+                                // Calculate the visual top margin:
+                                // SafeArea (padding.top) + Header centering offset ((72 - 48) / 2 = 12)
+                                final topPadding = MediaQuery.of(
+                                  context,
+                                ).padding.top;
+                                final visualTopMargin = topPadding + 12.0;
 
-                              return SingleChildScrollView(
-                                child: ConstrainedBox(
-                                  constraints: BoxConstraints(
-                                    minHeight: constraints.maxHeight,
-                                  ),
-                                  child: IntrinsicHeight(
-                                    child: Padding(
-                                      padding: EdgeInsets.symmetric(
-                                        horizontal: isMobile
-                                            ? visualTopMargin
-                                            : 48.0,
-                                      ),
-                                      child: Column(
-                                        children: [
-                                          HomeHeaderWidget(
-                                            isLoading: _isLoading,
-                                            onSettingsTap: () =>
-                                                _showSettingsDialog(context),
-                                          ),
-                                          Expanded(
-                                            child: HomeDropZoneWidget(
-                                              isDragging: _isDragging,
-                                              onTap: () => _pickFile(context),
+                                return SingleChildScrollView(
+                                  child: ConstrainedBox(
+                                    constraints: BoxConstraints(
+                                      minHeight: constraints.maxHeight,
+                                    ),
+                                    child: IntrinsicHeight(
+                                      child: Padding(
+                                        padding: EdgeInsets.symmetric(
+                                          horizontal: isMobile
+                                              ? visualTopMargin
+                                              : 48.0,
+                                        ),
+                                        child: Column(
+                                          children: [
+                                            HomeHeaderWidget(
+                                              isLoading: _isLoading,
+                                              onSettingsTap: () =>
+                                                  _showSettingsDialog(context),
                                             ),
-                                          ),
-                                          HomeFooterWidget(
-                                            isLoading: _isLoading,
-                                            showFeedbackBanner:
-                                                _showFeedbackBanner,
-                                            onCreateTap: () =>
-                                                _showCreateQuizFileDialog(
-                                                  context,
-                                                ),
-                                            onGenerateAITap: () =>
-                                                _generateQuestionsWithAI(
-                                                  context,
-                                                ),
-                                            onStudyModeTap: () =>
-                                                _startStudyModeWithAI(context),
-                                            onFeedbackTap: () =>
-                                                _openFeedbackForm(context),
-                                          ),
-                                        ],
+                                            Expanded(
+                                              child: HomeDropZoneWidget(
+                                                isDragging: _isDragging,
+                                                onTap: () => _pickFile(context),
+                                              ),
+                                            ),
+                                            HomeFooterWidget(
+                                              isLoading: _isLoading,
+                                              showFeedbackBanner:
+                                                  _showFeedbackBanner,
+                                              onCreateTap: () =>
+                                                  _showCreateQuizFileDialog(
+                                                    context,
+                                                  ),
+                                              onGenerateAITap: () =>
+                                                  _generateQuestionsWithAI(
+                                                    context,
+                                                  ),
+                                              onStudyModeTap: () =>
+                                                  _startStudyModeWithAI(
+                                                    context,
+                                                  ),
+                                              onFeedbackTap: () =>
+                                                  _openFeedbackForm(context),
+                                            ),
+                                          ],
+                                        ),
                                       ),
                                     ),
                                   ),
-                                ),
-                              );
-                            },
-                          ),
-                        ),
-                        if (_isDragging)
-                          Positioned.fill(
-                            child: HomeDragModeOverlay(
-                              hoveredMode: _hoveredDropMode,
+                                );
+                              },
                             ),
                           ),
-                        if (_isLoading)
-                          Positioned.fill(
-                            child: Container(
-                              color: Colors.black.withValues(alpha: 0.3),
-                              child: Center(
-                                child: Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    const QuizdyLoading(),
-                                    if (_loadingText != null) ...[
-                                      const SizedBox(height: 16),
-                                      Material(
-                                        color: Colors.transparent,
-                                        child: Text(
-                                          _loadingText!,
-                                          style: const TextStyle(
-                                            color: Colors.white,
-                                            fontSize: 14,
-                                            fontWeight: FontWeight.w500,
+                          if (_isDragging)
+                            Positioned.fill(
+                              child: HomeDragModeOverlay(
+                                hoveredMode: _hoveredDropMode,
+                              ),
+                            ),
+                          if (_isLoading)
+                            Positioned.fill(
+                              child: Container(
+                                color: Colors.black.withValues(alpha: 0.3),
+                                child: Center(
+                                  child: Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      const QuizdyLoading(),
+                                      if (_loadingText != null) ...[
+                                        const SizedBox(height: 16),
+                                        Material(
+                                          color: Colors.transparent,
+                                          child: Text(
+                                            _loadingText!,
+                                            style: const TextStyle(
+                                              color: Colors.white,
+                                              fontSize: 14,
+                                              fontWeight: FontWeight.w500,
+                                            ),
+                                            textAlign: TextAlign.center,
                                           ),
-                                          textAlign: TextAlign.center,
                                         ),
-                                      ),
+                                      ],
                                     ],
-                                  ],
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 );

--- a/lib/presentation/screens/quiz_file_execution_screen.dart
+++ b/lib/presentation/screens/quiz_file_execution_screen.dart
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'dart:async';
@@ -173,25 +174,42 @@ class _QuizFileExecutionScreenState extends State<QuizFileExecutionScreen> {
                   }
                 }
               },
-              child: Scaffold(
-                backgroundColor: isDark ? AppTheme.zinc900 : AppTheme.zinc50,
-                body: SafeArea(
-                  child: BlocConsumer<QuizExecutionBloc, QuizExecutionState>(
-                    listener: (context, state) {
-                      if (state is QuizExecutionCompleted) {
-                        // Handled by view
-                      }
-                    },
-                    builder: (context, state) {
-                      if (state is QuizExecutionInitial) {
-                        return const Center(child: QuizdyLoading());
-                      } else if (state is QuizExecutionInProgress) {
-                        return QuizInProgressView(state: state);
-                      } else if (state is QuizExecutionCompleted) {
-                        return QuizCompletedView(state: state);
-                      }
-                      return const SizedBox.shrink();
-                    },
+              child: AnnotatedRegion<SystemUiOverlayStyle>(
+                value: SystemUiOverlayStyle(
+                  statusBarColor: Colors.transparent,
+                  statusBarIconBrightness: isDark
+                      ? Brightness.light
+                      : Brightness.dark,
+                  statusBarBrightness: isDark
+                      ? Brightness.dark
+                      : Brightness.light,
+                  systemNavigationBarColor: isDark
+                      ? AppTheme.zinc900
+                      : AppTheme.zinc50,
+                  systemNavigationBarIconBrightness: isDark
+                      ? Brightness.light
+                      : Brightness.dark,
+                ),
+                child: Scaffold(
+                  backgroundColor: isDark ? AppTheme.zinc900 : AppTheme.zinc50,
+                  body: SafeArea(
+                    child: BlocConsumer<QuizExecutionBloc, QuizExecutionState>(
+                      listener: (context, state) {
+                        if (state is QuizExecutionCompleted) {
+                          // Handled by view
+                        }
+                      },
+                      builder: (context, state) {
+                        if (state is QuizExecutionInitial) {
+                          return const Center(child: QuizdyLoading());
+                        } else if (state is QuizExecutionInProgress) {
+                          return QuizInProgressView(state: state);
+                        } else if (state is QuizExecutionCompleted) {
+                          return QuizCompletedView(state: state);
+                        }
+                        return const SizedBox.shrink();
+                      },
+                    ),
                   ),
                 ),
               ),

--- a/lib/presentation/screens/study_screen.dart
+++ b/lib/presentation/screens/study_screen.dart
@@ -16,6 +16,7 @@ import 'package:desktop_drop/desktop_drop.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:quizdy/routes/app_router.dart';
@@ -381,193 +382,209 @@ class _StudyScreenViewState extends State<StudyScreenView> {
     // ignore: deprecated_member_use
     return WillPopScope(
       onWillPop: _confirmExit,
-      child: Scaffold(
-        backgroundColor: isDark ? AppTheme.zinc900 : AppTheme.zinc50,
-        extendBodyBehindAppBar: true,
-        extendBody: true,
-        bottomNavigationBar: StudyBottomNavigation(
-          quizFile: widget.quizFile,
-          generationMode: widget.generationMode,
-          originalText: widget.originalText,
-          hideStartQuizButton: widget.hideStartQuizButton,
-          onSave: _handleSave,
-          onImport: _handleChunkImport,
-          onExportPdf: () => handleExportPdf(
-            context: context,
-            questions: widget.quizFile?.questions ?? const [],
-          ),
-          onAddChunk: () async {
-            final localizations = AppLocalizations.of(context)!;
-            final result = await showDialog<Map<String, String>>(
+      child: AnnotatedRegion<SystemUiOverlayStyle>(
+        value: SystemUiOverlayStyle(
+          statusBarColor: Colors.transparent,
+          statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
+          statusBarBrightness: isDark ? Brightness.dark : Brightness.light,
+          systemNavigationBarColor: isDark ? AppTheme.zinc900 : AppTheme.zinc50,
+          systemNavigationBarIconBrightness: isDark
+              ? Brightness.light
+              : Brightness.dark,
+        ),
+        child: Scaffold(
+          backgroundColor: isDark ? AppTheme.zinc900 : AppTheme.zinc50,
+          extendBodyBehindAppBar: true,
+          extendBody: true,
+          bottomNavigationBar: StudyBottomNavigation(
+            quizFile: widget.quizFile,
+            generationMode: widget.generationMode,
+            originalText: widget.originalText,
+            hideStartQuizButton: widget.hideStartQuizButton,
+            onSave: _handleSave,
+            onImport: _handleChunkImport,
+            onExportPdf: () => handleExportPdf(
               context: context,
-              builder: (context) =>
-                  AddEditChunkDialog(localizations: localizations),
-            );
-
-            if (result != null && context.mounted) {
-              context.read<StudyExecutionBloc>().add(
-                AddStudyChunkRequested(
-                  title: result['title'] ?? '',
-                  content: result['text'] ?? '',
-                ),
+              questions: widget.quizFile?.questions ?? const [],
+            ),
+            onAddChunk: () async {
+              final localizations = AppLocalizations.of(context)!;
+              final result = await showDialog<Map<String, String>>(
+                context: context,
+                builder: (context) =>
+                    AddEditChunkDialog(localizations: localizations),
               );
-            }
-          },
-          onGenerateAI: () async {
-            final isAiAvailable =
-                await ServiceLocator.getIt<ConfigurationService>()
-                    .getIsAiAvailable();
 
-            if (!isAiAvailable) {
-              if (context.mounted) {
-                context.presentSnackBar(
-                  AppLocalizations.of(context)!.aiApiKeyRequired,
+              if (result != null && context.mounted) {
+                context.read<StudyExecutionBloc>().add(
+                  AddStudyChunkRequested(
+                    title: result['title'] ?? '',
+                    content: result['text'] ?? '',
+                  ),
                 );
               }
-              return;
-            }
+            },
+            onGenerateAI: () async {
+              final isAiAvailable =
+                  await ServiceLocator.getIt<ConfigurationService>()
+                      .getIsAiAvailable();
 
-            if (!context.mounted) return;
-            final config = await showDialog<AiStudyGenerationConfig>(
-              context: context,
-              barrierDismissible: false,
-              builder: (context) =>
-                  AiGenerateStudyDialog(questions: widget.quizFile?.questions),
-            );
+              if (!isAiAvailable) {
+                if (context.mounted) {
+                  context.presentSnackBar(
+                    AppLocalizations.of(context)!.aiApiKeyRequired,
+                  );
+                }
+                return;
+              }
 
-            if (config != null && context.mounted) {
-              final studyState = context.read<StudyExecutionBloc>().state;
-              final quizFile = _getCurrentQuizFile(studyState);
-              context.read<StudyExecutionBloc>().add(
-                GenerateAiStudyChunksRequested(
-                  config: config,
-                  quizContext: quizFile.toAIPromptContext(),
+              if (!context.mounted) return;
+              final config = await showDialog<AiStudyGenerationConfig>(
+                context: context,
+                barrierDismissible: false,
+                builder: (context) => AiGenerateStudyDialog(
+                  questions: widget.quizFile?.questions,
                 ),
               );
-            }
-          },
-        ),
-        appBar: StudyAppBar(
-          onConfirmExit: _confirmExit,
-          onEditCurrentChunk: () async {
-            final cubit = context.read<StudyEditorCubit>();
-            final bloc = context.read<StudyExecutionBloc>();
-            final blocState = bloc.state;
-            final chunkIndex = blocState.currentChunkIndex;
 
-            if (chunkIndex < 0 || chunkIndex >= blocState.chunks.length) {
-              return;
-            }
+              if (config != null && context.mounted) {
+                final studyState = context.read<StudyExecutionBloc>().state;
+                final quizFile = _getCurrentQuizFile(studyState);
+                context.read<StudyExecutionBloc>().add(
+                  GenerateAiStudyChunksRequested(
+                    config: config,
+                    quizContext: quizFile.toAIPromptContext(),
+                  ),
+                );
+              }
+            },
+          ),
+          appBar: StudyAppBar(
+            onConfirmExit: _confirmExit,
+            onEditCurrentChunk: () async {
+              final cubit = context.read<StudyEditorCubit>();
+              final bloc = context.read<StudyExecutionBloc>();
+              final blocState = bloc.state;
+              final chunkIndex = blocState.currentChunkIndex;
 
-            // Keep editor state aligned with current study state before opening the editor.
-            cubit.resetToSnapshot(blocState.chunks);
-            final snapshot = List.of(cubit.state.chunks);
+              if (chunkIndex < 0 || chunkIndex >= blocState.chunks.length) {
+                return;
+              }
 
-            final saved = await context.push<bool>(
-              AppRoutes.componentEditorScreen,
-              extra: {'cubit': cubit, 'chunkIndex': chunkIndex, 'pageIndex': 0},
-            );
-            if (saved == true) {
-              bloc.add(StudyChunksUpdated(cubit.state.chunks));
-            } else {
-              cubit.resetToSnapshot(snapshot);
-            }
-          },
-        ),
-        body: BlocBuilder<StudyExecutionBloc, StudyExecutionState>(
-          buildWhen: (previous, current) =>
-              previous.isIndexMode != current.isIndexMode,
-          builder: (context, state) {
-            final body = StudyBody(
-              onHandleFileReattachment: _handleFileReattachment,
-              onSave: _handleSave,
-            );
+              // Keep editor state aligned with current study state before opening the editor.
+              cubit.resetToSnapshot(blocState.chunks);
+              final snapshot = List.of(cubit.state.chunks);
 
-            if (!state.isIndexMode) return body;
+              final saved = await context.push<bool>(
+                AppRoutes.componentEditorScreen,
+                extra: {
+                  'cubit': cubit,
+                  'chunkIndex': chunkIndex,
+                  'pageIndex': 0,
+                },
+              );
+              if (saved == true) {
+                bloc.add(StudyChunksUpdated(cubit.state.chunks));
+              } else {
+                cubit.resetToSnapshot(snapshot);
+              }
+            },
+          ),
+          body: BlocBuilder<StudyExecutionBloc, StudyExecutionState>(
+            buildWhen: (previous, current) =>
+                previous.isIndexMode != current.isIndexMode,
+            builder: (context, state) {
+              final body = StudyBody(
+                onHandleFileReattachment: _handleFileReattachment,
+                onSave: _handleSave,
+              );
 
-            return DropTarget(
-              onDragDone: (details) {
-                if (ModalRoute.of(context)?.isCurrent != true) return;
-                setState(() => _isDragging = false);
-                if (ServiceLocator.getIt<DialogDropGuard>().isActive) return;
-                if (details.files.isNotEmpty) {
-                  final firstFile = details.files.first;
-                  if (firstFile.path.isNotEmpty) {
-                    if (!firstFile.name.toLowerCase().endsWith('.quiz')) {
-                      if (mounted) {
-                        context.presentSnackBar(
-                          AppLocalizations.of(context)!.errorInvalidFile,
-                        );
+              if (!state.isIndexMode) return body;
+
+              return DropTarget(
+                onDragDone: (details) {
+                  if (ModalRoute.of(context)?.isCurrent != true) return;
+                  setState(() => _isDragging = false);
+                  if (ServiceLocator.getIt<DialogDropGuard>().isActive) return;
+                  if (details.files.isNotEmpty) {
+                    final firstFile = details.files.first;
+                    if (firstFile.path.isNotEmpty) {
+                      if (!firstFile.name.toLowerCase().endsWith('.quiz')) {
+                        if (mounted) {
+                          context.presentSnackBar(
+                            AppLocalizations.of(context)!.errorInvalidFile,
+                          );
+                        }
+                        return;
                       }
-                      return;
+                      _importChunksFromFile(firstFile.path);
                     }
-                    _importChunksFromFile(firstFile.path);
                   }
-                }
-              },
-              onDragEntered: (_) {
-                if (!ServiceLocator.getIt<DialogDropGuard>().isActive) {
-                  setState(() => _isDragging = true);
-                }
-              },
-              onDragExited: (_) => setState(() => _isDragging = false),
-              child: Stack(
-                children: [
-                  body,
-                  if (_isDragging)
-                    Positioned.fill(
-                      child: Container(
-                        color: Theme.of(
-                          context,
-                        ).primaryColor.withValues(alpha: 0.15),
-                        child: Center(
-                          child: Container(
-                            padding: const EdgeInsets.all(32),
-                            decoration: BoxDecoration(
-                              color: Theme.of(context).cardColor,
-                              borderRadius: BorderRadius.circular(24),
-                              border: Border.all(
-                                color: Theme.of(context).primaryColor,
-                                width: 3,
-                              ),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Theme.of(
-                                    context,
-                                  ).primaryColor.withValues(alpha: 0.2),
-                                  blurRadius: 20,
-                                  offset: const Offset(0, 10),
-                                ),
-                              ],
-                            ),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Icon(
-                                  LucideIcons.upload,
-                                  size: 48,
+                },
+                onDragEntered: (_) {
+                  if (!ServiceLocator.getIt<DialogDropGuard>().isActive) {
+                    setState(() => _isDragging = true);
+                  }
+                },
+                onDragExited: (_) => setState(() => _isDragging = false),
+                child: Stack(
+                  children: [
+                    body,
+                    if (_isDragging)
+                      Positioned.fill(
+                        child: Container(
+                          color: Theme.of(
+                            context,
+                          ).primaryColor.withValues(alpha: 0.15),
+                          child: Center(
+                            child: Container(
+                              padding: const EdgeInsets.all(32),
+                              decoration: BoxDecoration(
+                                color: Theme.of(context).cardColor,
+                                borderRadius: BorderRadius.circular(24),
+                                border: Border.all(
                                   color: Theme.of(context).primaryColor,
+                                  width: 3,
                                 ),
-                                const SizedBox(height: 16),
-                                Text(
-                                  AppLocalizations.of(context)!.dropFileHere,
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .headlineMedium
-                                      ?.copyWith(
-                                        color: Theme.of(context).primaryColor,
-                                      ),
-                                ),
-                              ],
+                                boxShadow: [
+                                  BoxShadow(
+                                    color: Theme.of(
+                                      context,
+                                    ).primaryColor.withValues(alpha: 0.2),
+                                    blurRadius: 20,
+                                    offset: const Offset(0, 10),
+                                  ),
+                                ],
+                              ),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(
+                                    LucideIcons.upload,
+                                    size: 48,
+                                    color: Theme.of(context).primaryColor,
+                                  ),
+                                  const SizedBox(height: 16),
+                                  Text(
+                                    AppLocalizations.of(context)!.dropFileHere,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .headlineMedium
+                                        ?.copyWith(
+                                          color: Theme.of(context).primaryColor,
+                                        ),
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
                         ),
                       ),
-                    ),
-                ],
-              ),
-            );
-          },
+                  ],
+                ),
+              );
+            },
+          ),
         ),
       ),
     );

--- a/lib/presentation/widgets/app_update_banner.dart
+++ b/lib/presentation/widgets/app_update_banner.dart
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 
@@ -47,90 +48,97 @@ class _AppUpdateBannerState extends State<AppUpdateBanner> {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
 
-    return Column(
-      children: [
-        Material(
-          color: theme.colorScheme.secondaryContainer,
-          elevation: 2,
-          child: SafeArea(
-            bottom: false,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 8.0,
-                vertical: 8.0,
-              ),
-              child: Row(
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.close, size: 20),
-                    onPressed: () => setState(() => _isVisible = false),
-                    color: theme.colorScheme.onPrimary,
-                  ),
-                  const SizedBox(width: 8),
-                  Container(
-                    width: 40,
-                    height: 40,
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.secondary,
-                      borderRadius: BorderRadius.circular(8),
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: const SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent,
+        statusBarIconBrightness: Brightness.light,
+        statusBarBrightness: Brightness.dark,
+      ),
+      child: Column(
+        children: [
+          Material(
+            color: theme.colorScheme.secondaryContainer,
+            elevation: 2,
+            child: SafeArea(
+              bottom: false,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 8.0,
+                  vertical: 8.0,
+                ),
+                child: Row(
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.close, size: 20),
+                      onPressed: () => setState(() => _isVisible = false),
+                      color: theme.colorScheme.onPrimary,
                     ),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: SvgPicture.asset(
-                        'images/pictorial_mark.svg',
-                        width: 40,
-                        height: 40,
-                        fit: BoxFit.cover,
+                    const SizedBox(width: 8),
+                    Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.secondary,
+                        borderRadius: BorderRadius.circular(8),
                       ),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          l10n.updateAvailableTitle,
-                          style: theme.textTheme.titleMedium?.copyWith(
-                            color: theme.colorScheme.onPrimary,
-                            fontWeight: FontWeight.bold,
-                          ),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: SvgPicture.asset(
+                          'images/pictorial_mark.svg',
+                          width: 40,
+                          height: 40,
+                          fit: BoxFit.cover,
                         ),
-                        Text(
-                          l10n.updateAvailableMessage(widget.newVersion),
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onPrimary.withAlpha(200),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            l10n.updateAvailableTitle,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              color: theme.colorScheme.onPrimary,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                          Text(
+                            l10n.updateAvailableMessage(widget.newVersion),
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onPrimary.withAlpha(200),
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                      onPressed: widget.onUpdatePressed,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: theme.colorScheme.secondary,
+                        foregroundColor: theme.colorScheme.onPrimary,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(20),
                         ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  ElevatedButton(
-                    onPressed: widget.onUpdatePressed,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: theme.colorScheme.secondary,
-                      foregroundColor: theme.colorScheme.onPrimary,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(20),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
+                        ),
                       ),
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 8,
-                      ),
+                      child: Text(l10n.updateButton),
                     ),
-                    child: Text(l10n.updateButton),
-                  ),
-                  const SizedBox(width: 8),
-                ],
+                    const SizedBox(width: 8),
+                  ],
+                ),
               ),
             ),
           ),
-        ),
-        Expanded(child: widget.child),
-      ],
+          Expanded(child: widget.child),
+        ],
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.13.0+39
+version: 1.13.1+40
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Fixes: status bar icons switch to white while the update banner is visible on Home; on banner dismissal the app restores theme-based status bar colors. Includes: home_screen, quiz_file_execution_screen, study_screen, app_update_banner, changelog and pubspec version bump to 1.13.1.