### PR TITLE
feat: implement Flashcards study mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.13.1] - TBD
 
-- feat(study): Added a new Flashcards study mode with swiping mechanics, 3D flip animations, Leitner-style progression, and LaTeX support.
+- feat(study): Added a new Flashcards study mode with swiping mechanics, flip animations, Leitner-style progression, and LaTeX support.
 - fix(mobile): Improved readability of the system status bar during in-app update prompts, dynamically adjusting icon colors to ensure they remain clearly visible over the update banner and seamlessly restore to their native theme once dismissed.
 
 ## [1.13.0] - 2026-04-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.13.1] - TBD
 
+- feat(study): Added a new Flashcards study mode with swiping mechanics, 3D flip animations, Leitner-style progression, and LaTeX support.
 - fix(mobile): Improved readability of the system status bar during in-app update prompts, dynamically adjusting icon colors to ensure they remain clearly visible over the update banner and seamlessly restore to their native theme once dismissed.
 
 ## [1.13.0] - 2026-04-29

--- a/lib/core/l10n/app_ar.arb
+++ b/lib/core/l10n/app_ar.arb
@@ -2823,5 +2823,15 @@
   "forceUpdateMessage": "مطلوب تحديث إلزامي لمتابعة استخدام Quizdy. يرجى تحديث التطبيق.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "دراسة البطاقات",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "البطاقات التعليمية",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "لا توجد أسئلة متاحة للدراسة.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "لقد راجعت جميع البطاقات!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "إعادة البدء",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_ca.arb
+++ b/lib/core/l10n/app_ca.arb
@@ -2507,5 +2507,15 @@
   "forceUpdateMessage": "Cal una actualització obligatòria per continuar utilitzant Quizdy. Si us plau, actualitzeu l'aplicació.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "Estudiar Flashcards",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "Mode Flashcards",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "No hi ha preguntes disponibles per estudiar.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "Has repassat totes les targetes!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "Tornar a començar",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -2505,5 +2505,15 @@
   "forceUpdateMessage": "Ein obligatorisches Update ist erforderlich, um Quizdy weiterhin zu verwenden. Bitte aktualisieren Sie die App.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "Karteikarten lernen",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "Karteikarten",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "Keine Fragen zum Lernen verfügbar.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "Du hast alle Karteikarten überprüft!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "Neustart",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -289,10 +289,6 @@
   "@requestFileNameTitle": {
     "description": "Titel für den Dialog zur Anfrage des Dateinamens."
   },
-  "fileNameHint": "Dateiname",
-  "@fileNameHint": {
-    "description": "Hinweistext für die Dateiname-Eingabe."
-  },
   "emptyFileNameMessage": "Der Dateiname darf nicht leer sein.",
   "@emptyFileNameMessage": {
     "description": "Fehlermeldung, wenn der Dateiname leer ist."

--- a/lib/core/l10n/app_el.arb
+++ b/lib/core/l10n/app_el.arb
@@ -1405,5 +1405,15 @@
   "forceUpdateMessage": "Απαιτείται υποχρεωτική ενημέρωση για να συνεχίσετε να χρησιμοποιείτε το Quizdy. Παρακαλούμε ενημερώστε την εφαρμογή.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "Μελέτη Flashcards",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "Λειτουργία Flashcards",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "Δεν υπάρχουν διαθέσιμες ερωτήσεις για μελέτη.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "Έχετε ελέγξει όλες τις κάρτες!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "Επανεκκίνηση",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -2890,5 +2890,25 @@
   "forceUpdateMessage": "A mandatory update is required to continue using Quizdy. Please update the app.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
+  },
+  "startFlashcardsButton": "Study Flashcards",
+  "@startFlashcardsButton": {
+    "description": "Button text to start the flashcards study mode"
+  },
+  "flashcardsModeTitle": "Flashcards",
+  "@flashcardsModeTitle": {
+    "description": "Title for the flashcards mode screen"
+  },
+  "flashcardsEmptyState": "No questions available to study.",
+  "@flashcardsEmptyState": {
+    "description": "Empty state message for flashcards"
+  },
+  "flashcardsCompletionMessage": "You've reviewed all flashcards!",
+  "@flashcardsCompletionMessage": {
+    "description": "Message shown when all flashcards are reviewed"
+  },
+  "flashcardsRestartButton": "Restart",
+  "@flashcardsRestartButton": {
+    "description": "Button to restart the flashcards session"
   }
 }

--- a/lib/core/l10n/app_es.arb
+++ b/lib/core/l10n/app_es.arb
@@ -2644,5 +2644,25 @@
   "forceUpdateMessage": "Se requiere una actualización obligatoria para continuar usando Quizdy. Por favor, actualiza la aplicación.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
+  },
+  "startFlashcardsButton": "Flashcards",
+  "@startFlashcardsButton": {
+    "description": "Button text to start the flashcards study mode"
+  },
+  "flashcardsModeTitle": "Modo Flashcards",
+  "@flashcardsModeTitle": {
+    "description": "Title for the flashcards mode screen"
+  },
+  "flashcardsEmptyState": "No hay preguntas disponibles para estudiar.",
+  "@flashcardsEmptyState": {
+    "description": "Empty state message for flashcards"
+  },
+  "flashcardsCompletionMessage": "¡Has repasado todas las tarjetas!",
+  "@flashcardsCompletionMessage": {
+    "description": "Message shown when all flashcards are reviewed"
+  },
+  "flashcardsRestartButton": "Volver a empezar",
+  "@flashcardsRestartButton": {
+    "description": "Button to restart the flashcards session"
   }
 }

--- a/lib/core/l10n/app_eu.arb
+++ b/lib/core/l10n/app_eu.arb
@@ -2405,5 +2405,15 @@
   "forceUpdateMessage": "Derrigorrezko eguneratzea beharrezkoa da Quizdy erabiltzen jarraitzak. Mesedez, eguneratu aplikazioa.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "Flashcardak ikasi",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "Flashcard modua",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "Ez dago galderarik eskuragarri ikasteko.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "Txartel guztiak berrikusi dituzu!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "Berrabiarazi",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_fr.arb
+++ b/lib/core/l10n/app_fr.arb
@@ -2450,5 +2450,15 @@
   "forceUpdateMessage": "Une mise à jour obligatoire est requise pour continuer à utiliser Quizdy. Veuillez mettre à jour l'application.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "Étudier les Flashcards",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "Mode Flashcards",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "Aucune question disponible pour l'étude.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "Vous avez révisé toutes les cartes !",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "Redémarrer",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_gl.arb
+++ b/lib/core/l10n/app_gl.arb
@@ -2405,5 +2405,15 @@
   "forceUpdateMessage": "Requírese unha actualización obrigatoria para continuar usando Quizdy. Por favor, actualiza a aplicación.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "Estudar Flashcards",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "Modo Flashcards",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "Non hai preguntas dispoñibles para estudar.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "Revisaches todas as tarxetas!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "Reiniciar",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_hi.arb
+++ b/lib/core/l10n/app_hi.arb
@@ -2408,5 +2408,15 @@
   "forceUpdateMessage": "Quizdy का उपयोग जारी रखने के लिए एक अनिवार्य अपडेट आवश्यक है। कृपया ऐप अपडेट करें।",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "फ़्लैशकार्ड का अध्ययन करें",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "फ़्लैशकार्ड",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "अध्ययन के लिए कोई प्रश्न उपलब्ध नहीं है।",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "आपने सभी फ़्लैशकार्ड की समीक्षा कर ली है!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "पुनरारंभ करें",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_it.arb
+++ b/lib/core/l10n/app_it.arb
@@ -2459,5 +2459,15 @@
   "forceUpdateMessage": "È necessario un aggiornamento obbligatorio per continuare a utilizzare Quizdy. Aggiorna l'app.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "Studia Flashcards",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "Modalità Flashcards",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "Nessuna domanda disponibile per lo studio.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "Hai esaminato tutte le flashcard!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "Riavvia",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_ja.arb
+++ b/lib/core/l10n/app_ja.arb
@@ -2408,5 +2408,15 @@
   "forceUpdateMessage": "Quizdyを引き続き使用するには、強制アップデートが必要です。アプリをアップデートしてください。",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "フラッシュカードを学習",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "フラッシュカード",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "学習できる質問はありません。",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "すべてのカードを確認しました！",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "再開する",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_ka.arb
+++ b/lib/core/l10n/app_ka.arb
@@ -1097,5 +1097,15 @@
   "forceUpdateMessage": "Quizdy-ს გამოყენების გასაგრძელებლად საჭიროა სავალდებულო განახლება. გთხოვთ, განაახლოთ აპი.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "ფლეშ ბარათების შესწავლა",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "ფლეშ ბარათები",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "შესასწავლი კითხვები არ არის ხელმისაწვდომი.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "თქვენ გადახედეთ ყველა ბარათს!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "გადატვირთვა",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_ko.arb
+++ b/lib/core/l10n/app_ko.arb
@@ -1097,5 +1097,15 @@
   "forceUpdateMessage": "Quizdy를 계속 사용하려면 필수 업데이트가 필요합니다. 앱을 업데이트해 주세요.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "플래시카드 학습",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "플래시카드",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "학습할 질문이 없습니다.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "모든 플래시카드를 검토했습니다!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "다시 시작",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_pt.arb
+++ b/lib/core/l10n/app_pt.arb
@@ -2496,5 +2496,15 @@
   "forceUpdateMessage": "É necessária uma atualização obrigatória para continuar a utilizar o Quizdy. Por favor, atualize a aplicação.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "Estudar Flashcards",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "Modo Flashcards",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "Nenhuma pergunta disponível para estudo.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "Você revisou todos os flashcards!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "Reiniciar",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_ru.arb
+++ b/lib/core/l10n/app_ru.arb
@@ -1112,5 +1112,15 @@
   "forceUpdateMessage": "Для продолжения использования Quizdy необходимо обязательное обновление. Пожалуйста, обновите приложение.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "Изучать карточки",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "Флеш-карточки",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "Нет доступных вопросов для изучения.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "Вы просмотрели все карточки!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "Начать заново",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_uk.arb
+++ b/lib/core/l10n/app_uk.arb
@@ -1130,5 +1130,15 @@
   "forceUpdateMessage": "Для продовження використання Quizdy необхідне обов'язкове оновлення. Будь ласка, оновіть програму.",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "Вивчати картки",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "Флеш-картки",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "Немає доступних питань для вивчення.",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "Ви переглянули всі картки!",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "Почати знову",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -2457,5 +2457,15 @@
   "forceUpdateMessage": "需要强制更新才能继续使用 Quizdy。请更新应用。",
   "@forceUpdateMessage": {
     "description": "Body message of the force update dialog."
-  }
+  },
+  "startFlashcardsButton": "学习抽认卡",
+  "@startFlashcardsButton": {"description": "Button text to start the flashcards study mode"},
+  "flashcardsModeTitle": "抽认卡",
+  "@flashcardsModeTitle": {"description": "Title for the flashcards mode screen"},
+  "flashcardsEmptyState": "没有可供学习的问题。",
+  "@flashcardsEmptyState": {"description": "Empty state message for flashcards"},
+  "flashcardsCompletionMessage": "您已复习完所有抽认卡！",
+  "@flashcardsCompletionMessage": {"description": "Message shown when all flashcards are reviewed"},
+  "flashcardsRestartButton": "重新开始",
+  "@flashcardsRestartButton": {"description": "Button to restart the flashcards session"}
 }

--- a/lib/presentation/screens/flashcards_screen.dart
+++ b/lib/presentation/screens/flashcards_screen.dart
@@ -1,0 +1,282 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:flutter_card_swiper/flutter_card_swiper.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:quizdy/core/l10n/app_localizations.dart';
+import 'package:quizdy/core/theme/app_theme.dart';
+import 'package:quizdy/core/theme/extensions/custom_colors.dart';
+import 'package:quizdy/domain/models/quiz/question.dart';
+import 'package:quizdy/domain/models/quiz/quiz_file.dart';
+import 'package:quizdy/presentation/screens/widgets/common/quizdy_app_bar.dart';
+import 'package:quizdy/presentation/screens/widgets/flashcard_widget.dart';
+import 'package:quizdy/presentation/widgets/quizdy_button.dart';
+
+class FlashcardsScreen extends StatefulWidget {
+  final QuizFile quizFile;
+
+  const FlashcardsScreen({super.key, required this.quizFile});
+
+  @override
+  State<FlashcardsScreen> createState() => _FlashcardsScreenState();
+}
+
+class _FlashcardsScreenState extends State<FlashcardsScreen> {
+  final CardSwiperController _swiperController = CardSwiperController();
+  
+  late List<Question> _activeQueue;
+  bool _isFinished = false;
+  int _currentIndex = 0;
+  
+  // Track flip state so we know if they actually reviewed it
+  // (Optional: enforce flipping before swiping, but let's keep it simple first)
+  bool _currentCardFlipped = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _initQueue();
+  }
+
+  void _initQueue() {
+    // We start with a shuffled list to make studying more effective
+    final shuffled = widget.quizFile.questions.toList()..shuffle();
+    _activeQueue = List.from(shuffled);
+    _isFinished = _activeQueue.isEmpty;
+    _currentIndex = 0;
+    _currentCardFlipped = false;
+  }
+
+  @override
+  void dispose() {
+    _swiperController.dispose();
+    super.dispose();
+  }
+
+  bool _onSwipe(
+    int previousIndex,
+    int? currentIndex,
+    CardSwiperDirection direction,
+  ) {
+    if (previousIndex >= _activeQueue.length) return false;
+
+    final swipedQuestion = _activeQueue[previousIndex];
+
+    if (direction == CardSwiperDirection.left) {
+      // Incorrect / Hard -> Send to back of the queue
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            _activeQueue.add(swipedQuestion);
+          });
+        }
+      });
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        setState(() {
+          _currentCardFlipped = false;
+          // If we reached the end of the queue (including dynamically added ones)
+          if (currentIndex == null || currentIndex >= _activeQueue.length) {
+            _isFinished = true;
+          } else {
+            _currentIndex = currentIndex;
+          }
+        });
+      }
+    });
+
+    return true;
+  }
+
+  Widget _buildFinishedState() {
+    final localizations = AppLocalizations.of(context)!;
+    final customColors = Theme.of(context).extension<CustomColors>();
+
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(24),
+            decoration: BoxDecoration(
+              color: customColors?.success?.withValues(alpha: 0.1) ?? AppTheme.primaryColor.withValues(alpha: 0.1),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              LucideIcons.checkCircle2,
+              size: 80,
+              color: customColors?.success ?? AppTheme.primaryColor,
+            ),
+          ),
+          const SizedBox(height: 32),
+          Text(
+            localizations.flashcardsCompletionMessage,
+            style: const TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 48),
+          QuizdyButton(
+            title: localizations.flashcardsRestartButton,
+            icon: LucideIcons.rotateCcw,
+            onPressed: () {
+              setState(() {
+                _initQueue();
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context)!;
+    final customColors = Theme.of(context).extension<CustomColors>();
+
+    return Scaffold(
+      appBar: QuizdyAppBar(
+        title: Text(
+          localizations.flashcardsModeTitle,
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onPrimary,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: Icon(
+            Icons.close,
+            color: Theme.of(context).colorScheme.onPrimary,
+          ),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Progress Indicator
+            if (!_isFinished && _activeQueue.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: LinearProgressIndicator(
+                          value: _currentIndex / _activeQueue.length,
+                          backgroundColor: Theme.of(context).dividerColor,
+                          valueColor: const AlwaysStoppedAnimation<Color>(
+                            AppTheme.primaryColor,
+                          ),
+                          minHeight: 8,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Text(
+                      '${_currentIndex + 1} / ${_activeQueue.length}',
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+            // Card Swiper Area
+            Expanded(
+              child: _isFinished
+                  ? _buildFinishedState()
+                  : _activeQueue.isEmpty
+                      ? Center(child: Text(localizations.flashcardsEmptyState))
+                      : Padding(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 24, vertical: 16),
+                          child: CardSwiper(
+                            controller: _swiperController,
+                            cardsCount: _activeQueue.length,
+                            onSwipe: _onSwipe,
+                            numberOfCardsDisplayed: 2,
+                            padding: EdgeInsets.zero,
+                            backCardOffset: const Offset(0, 15),
+                            allowedSwipeDirection: const AllowedSwipeDirection.symmetric(horizontal: true),
+                            cardBuilder: (
+                              context,
+                              index,
+                              horizontalThresholdPercentage,
+                              verticalThresholdPercentage,
+                            ) {
+                              return FlashcardWidget(
+                                question: _activeQueue[index],
+                                isFlipped: _currentCardFlipped,
+                                onTap: () {
+                                  setState(() {
+                                    _currentCardFlipped = !_currentCardFlipped;
+                                  });
+                                },
+                              );
+                            },
+                          ),
+                        ),
+            ),
+
+            // Action Buttons
+            if (!_isFinished && _activeQueue.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.all(24.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    FloatingActionButton.large(
+                      heroTag: 'btn_wrong',
+                      onPressed: () => _swiperController.swipe(CardSwiperDirection.left),
+                      backgroundColor: Theme.of(context).colorScheme.error,
+                      elevation: 4,
+                      child: Icon(
+                        LucideIcons.x,
+                        color: Theme.of(context).colorScheme.onError,
+                        size: 40,
+                      ),
+                    ),
+                    FloatingActionButton.large(
+                      heroTag: 'btn_correct',
+                      onPressed: () => _swiperController.swipe(CardSwiperDirection.right),
+                      backgroundColor: customColors?.success ?? Colors.green,
+                      elevation: 4,
+                      child: const Icon(
+                        LucideIcons.check,
+                        color: Colors.white,
+                        size: 40,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/flashcards_screen.dart
+++ b/lib/presentation/screens/flashcards_screen.dart
@@ -37,11 +37,11 @@ class FlashcardsScreen extends StatefulWidget {
 
 class _FlashcardsScreenState extends State<FlashcardsScreen> {
   final CardSwiperController _swiperController = CardSwiperController();
-  
+
   late List<Question> _activeQueue;
   bool _isFinished = false;
   int _currentIndex = 0;
-  
+
   // Track flip state so we know if they actually reviewed it
   // (Optional: enforce flipping before swiping, but let's keep it simple first)
   bool _currentCardFlipped = false;
@@ -115,7 +115,9 @@ class _FlashcardsScreenState extends State<FlashcardsScreen> {
           Container(
             padding: const EdgeInsets.all(24),
             decoration: BoxDecoration(
-              color: customColors?.success?.withValues(alpha: 0.1) ?? AppTheme.primaryColor.withValues(alpha: 0.1),
+              color:
+                  customColors?.success?.withValues(alpha: 0.1) ??
+                  AppTheme.primaryColor.withValues(alpha: 0.1),
               shape: BoxShape.circle,
             ),
             child: Icon(
@@ -127,10 +129,7 @@ class _FlashcardsScreenState extends State<FlashcardsScreen> {
           const SizedBox(height: 32),
           Text(
             localizations.flashcardsCompletionMessage,
-            style: const TextStyle(
-              fontSize: 24,
-              fontWeight: FontWeight.bold,
-            ),
+            style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 48),
@@ -177,7 +176,10 @@ class _FlashcardsScreenState extends State<FlashcardsScreen> {
             // Progress Indicator
             if (!_isFinished && _activeQueue.isNotEmpty)
               Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 16,
+                ),
                 child: Row(
                   children: [
                     Expanded(
@@ -210,19 +212,25 @@ class _FlashcardsScreenState extends State<FlashcardsScreen> {
               child: _isFinished
                   ? _buildFinishedState()
                   : _activeQueue.isEmpty
-                      ? Center(child: Text(localizations.flashcardsEmptyState))
-                      : Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 24, vertical: 16),
-                          child: CardSwiper(
-                            controller: _swiperController,
-                            cardsCount: _activeQueue.length,
-                            onSwipe: _onSwipe,
-                            numberOfCardsDisplayed: 2,
-                            padding: EdgeInsets.zero,
-                            backCardOffset: const Offset(0, 15),
-                            allowedSwipeDirection: const AllowedSwipeDirection.symmetric(horizontal: true),
-                            cardBuilder: (
+                  ? Center(child: Text(localizations.flashcardsEmptyState))
+                  : Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 16,
+                      ),
+                      child: CardSwiper(
+                        controller: _swiperController,
+                        cardsCount: _activeQueue.length,
+                        onSwipe: _onSwipe,
+                        numberOfCardsDisplayed: 2,
+                        padding: EdgeInsets.zero,
+                        backCardOffset: const Offset(0, 15),
+                        allowedSwipeDirection:
+                            const AllowedSwipeDirection.symmetric(
+                              horizontal: true,
+                            ),
+                        cardBuilder:
+                            (
                               context,
                               index,
                               horizontalThresholdPercentage,
@@ -238,8 +246,8 @@ class _FlashcardsScreenState extends State<FlashcardsScreen> {
                                 },
                               );
                             },
-                          ),
-                        ),
+                      ),
+                    ),
             ),
 
             // Action Buttons
@@ -251,7 +259,8 @@ class _FlashcardsScreenState extends State<FlashcardsScreen> {
                   children: [
                     FloatingActionButton.large(
                       heroTag: 'btn_wrong',
-                      onPressed: () => _swiperController.swipe(CardSwiperDirection.left),
+                      onPressed: () =>
+                          _swiperController.swipe(CardSwiperDirection.left),
                       backgroundColor: Theme.of(context).colorScheme.error,
                       elevation: 4,
                       child: Icon(
@@ -262,7 +271,8 @@ class _FlashcardsScreenState extends State<FlashcardsScreen> {
                     ),
                     FloatingActionButton.large(
                       heroTag: 'btn_correct',
-                      onPressed: () => _swiperController.swipe(CardSwiperDirection.right),
+                      onPressed: () =>
+                          _swiperController.swipe(CardSwiperDirection.right),
                       backgroundColor: customColors?.success ?? Colors.green,
                       elevation: 4,
                       child: const Icon(

--- a/lib/presentation/screens/quiz_loaded_screen.dart
+++ b/lib/presentation/screens/quiz_loaded_screen.dart
@@ -807,6 +807,53 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
                   context.push(AppRoutes.quizFileExecutionScreen);
                 }
               },
+              onPlayFlashcards: () async {
+                // Filter enabled questions first
+                final enabledQuestions = cachedQuizFile.questions
+                    .where((question) => question.isEnabled)
+                    .toList();
+
+                if (enabledQuestions.isEmpty) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                        AppLocalizations.of(context)!.noEnabledQuestionsError,
+                      ),
+                      backgroundColor: Theme.of(
+                        context,
+                      ).extension<CustomColors>()!.warning,
+                    ),
+                  );
+                  return;
+                }
+
+                // If selection mode is active, filter selected + enabled
+                QuizFile quizFileToUse = cachedQuizFile;
+                if (_isSelectionMode && _selectedQuestions.isNotEmpty) {
+                  final selectedQuestions = <Question>[];
+                  for (final index in _selectedQuestions) {
+                    if (index < cachedQuizFile.questions.length &&
+                        cachedQuizFile.questions[index].isEnabled) {
+                      selectedQuestions.add(cachedQuizFile.questions[index]);
+                    }
+                  }
+                  
+                  if (selectedQuestions.isEmpty) {
+                      return; // Handle case where none selected are enabled
+                  }
+                  
+                  quizFileToUse = cachedQuizFile.copyWith(
+                    questions: selectedQuestions,
+                  );
+                } else {
+                    quizFileToUse = cachedQuizFile.copyWith(
+                        questions: enabledQuestions
+                    );
+                }
+
+                ServiceLocator.registerQuizFile(quizFileToUse);
+                context.push(AppRoutes.flashcardsScreen);
+              },
             ),
           ),
         ),

--- a/lib/presentation/screens/quiz_loaded_screen.dart
+++ b/lib/presentation/screens/quiz_loaded_screen.dart
@@ -837,18 +837,18 @@ class _QuizLoadedScreenState extends State<QuizLoadedScreen> {
                       selectedQuestions.add(cachedQuizFile.questions[index]);
                     }
                   }
-                  
+
                   if (selectedQuestions.isEmpty) {
-                      return; // Handle case where none selected are enabled
+                    return; // Handle case where none selected are enabled
                   }
-                  
+
                   quizFileToUse = cachedQuizFile.copyWith(
                     questions: selectedQuestions,
                   );
                 } else {
-                    quizFileToUse = cachedQuizFile.copyWith(
-                        questions: enabledQuestions
-                    );
+                  quizFileToUse = cachedQuizFile.copyWith(
+                    questions: enabledQuestions,
+                  );
                 }
 
                 ServiceLocator.registerQuizFile(quizFileToUse);

--- a/lib/presentation/screens/widgets/flashcard_widget.dart
+++ b/lib/presentation/screens/widgets/flashcard_widget.dart
@@ -16,6 +16,7 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:quizdy/domain/models/quiz/question.dart';
+import 'package:quizdy/presentation/widgets/quizdy_latex_text.dart';
 import 'package:quizdy/core/theme/app_theme.dart';
 import 'package:quizdy/core/theme/extensions/custom_colors.dart';
 import 'dart:convert';
@@ -138,14 +139,14 @@ class _FlashcardWidgetState extends State<FlashcardWidget>
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           _buildImage(widget.question.image),
-          Text(
+          QuizdyLatexText(
             widget.question.text,
+            textAlign: TextAlign.center,
             style: const TextStyle(
               fontSize: 20,
               fontWeight: FontWeight.w600,
               height: 1.4,
             ),
-            textAlign: TextAlign.center,
           ),
         ],
       ),
@@ -204,13 +205,13 @@ class _FlashcardWidgetState extends State<FlashcardWidget>
               ...correctOptions.map(
                 (opt) => Padding(
                   padding: const EdgeInsets.symmetric(vertical: 4),
-                  child: Text(
+                  child: QuizdyLatexText(
                     opt,
+                    textAlign: TextAlign.center,
                     style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
                     ),
-                    textAlign: TextAlign.center,
                   ),
                 ),
               ),
@@ -228,13 +229,13 @@ class _FlashcardWidgetState extends State<FlashcardWidget>
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 8),
-                Text(
+                QuizdyLatexText(
                   widget.question.explanation,
+                  textAlign: TextAlign.center,
                   style: const TextStyle(
                     fontSize: 16,
                     height: 1.5,
                   ),
-                  textAlign: TextAlign.center,
                 ),
               ]
             ],

--- a/lib/presentation/screens/widgets/flashcard_widget.dart
+++ b/lib/presentation/screens/widgets/flashcard_widget.dart
@@ -51,9 +51,10 @@ class _FlashcardWidgetState extends State<FlashcardWidget>
       vsync: this,
       duration: const Duration(milliseconds: 300),
     );
-    _animation = Tween<double>(begin: 0, end: pi).animate(
-      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
-    );
+    _animation = Tween<double>(
+      begin: 0,
+      end: pi,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
 
     if (widget.isFlipped) {
       _controller.value = 1.0;
@@ -105,10 +106,7 @@ class _FlashcardWidgetState extends State<FlashcardWidget>
           constraints: const BoxConstraints(maxHeight: 200),
           child: ClipRRect(
             borderRadius: BorderRadius.circular(12),
-            child: Image.memory(
-              bytes,
-              fit: BoxFit.contain,
-            ),
+            child: Image.memory(bytes, fit: BoxFit.contain),
           ),
         ),
       );
@@ -155,7 +153,7 @@ class _FlashcardWidgetState extends State<FlashcardWidget>
 
   Widget _buildBack() {
     final customColors = Theme.of(context).extension<CustomColors>();
-    
+
     // Get correct answers text
     final correctOptions = widget.question.correctAnswers
         .map((index) {
@@ -176,13 +174,17 @@ class _FlashcardWidgetState extends State<FlashcardWidget>
           borderRadius: BorderRadius.circular(24),
           boxShadow: [
             BoxShadow(
-              color: customColors?.success?.withValues(alpha: 0.2) ?? Colors.black.withValues(alpha: 0.1),
+              color:
+                  customColors?.success?.withValues(alpha: 0.2) ??
+                  Colors.black.withValues(alpha: 0.1),
               blurRadius: 15,
               offset: const Offset(0, 5),
             ),
           ],
           border: Border.all(
-            color: customColors?.success?.withValues(alpha: 0.5) ?? AppTheme.primaryColor,
+            color:
+                customColors?.success?.withValues(alpha: 0.5) ??
+                AppTheme.primaryColor,
             width: 2,
           ),
         ),
@@ -232,12 +234,9 @@ class _FlashcardWidgetState extends State<FlashcardWidget>
                 QuizdyLatexText(
                   widget.question.explanation,
                   textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    height: 1.5,
-                  ),
+                  style: const TextStyle(fontSize: 16, height: 1.5),
                 ),
-              ]
+              ],
             ],
           ),
         ),

--- a/lib/presentation/screens/widgets/flashcard_widget.dart
+++ b/lib/presentation/screens/widgets/flashcard_widget.dart
@@ -1,0 +1,266 @@
+// Copyright (C) 2026 Víctor Carreras
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:quizdy/domain/models/quiz/question.dart';
+import 'package:quizdy/core/theme/app_theme.dart';
+import 'package:quizdy/core/theme/extensions/custom_colors.dart';
+import 'dart:convert';
+
+class FlashcardWidget extends StatefulWidget {
+  final Question question;
+  final bool isFlipped;
+  final VoidCallback? onTap;
+
+  const FlashcardWidget({
+    super.key,
+    required this.question,
+    this.isFlipped = false,
+    this.onTap,
+  });
+
+  @override
+  State<FlashcardWidget> createState() => _FlashcardWidgetState();
+}
+
+class _FlashcardWidgetState extends State<FlashcardWidget>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+  bool _isFront = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _isFront = !widget.isFlipped;
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _animation = Tween<double>(begin: 0, end: pi).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+
+    if (widget.isFlipped) {
+      _controller.value = 1.0;
+    }
+  }
+
+  @override
+  void didUpdateWidget(FlashcardWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isFlipped != oldWidget.isFlipped) {
+      if (widget.isFlipped) {
+        _controller.forward();
+        _isFront = false;
+      } else {
+        _controller.reverse();
+        _isFront = true;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _flipCard() {
+    if (_isFront) {
+      _controller.forward();
+    } else {
+      _controller.reverse();
+    }
+    setState(() {
+      _isFront = !_isFront;
+    });
+    widget.onTap?.call();
+  }
+
+  Widget _buildImage(String? base64String) {
+    if (base64String == null || base64String.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    try {
+      final parts = base64String.split(',');
+      final bytes = base64Decode(parts.length > 1 ? parts[1] : parts[0]);
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 16.0),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 200),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: Image.memory(
+              bytes,
+              fit: BoxFit.contain,
+            ),
+          ),
+        ),
+      );
+    } catch (e) {
+      return const SizedBox.shrink();
+    }
+  }
+
+  Widget _buildFront() {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).cardColor,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.1),
+            blurRadius: 10,
+            offset: const Offset(0, 5),
+          ),
+        ],
+        border: Border.all(
+          color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
+          width: 1,
+        ),
+      ),
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          _buildImage(widget.question.image),
+          Text(
+            widget.question.text,
+            style: const TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w600,
+              height: 1.4,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBack() {
+    final customColors = Theme.of(context).extension<CustomColors>();
+    
+    // Get correct answers text
+    final correctOptions = widget.question.correctAnswers
+        .map((index) {
+          if (index >= 0 && index < widget.question.options.length) {
+            return widget.question.options[index];
+          }
+          return '';
+        })
+        .where((text) => text.isNotEmpty)
+        .toList();
+
+    return Transform(
+      alignment: Alignment.center,
+      transform: Matrix4.identity()..rotateY(pi),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).cardColor,
+          borderRadius: BorderRadius.circular(24),
+          boxShadow: [
+            BoxShadow(
+              color: customColors?.success?.withValues(alpha: 0.2) ?? Colors.black.withValues(alpha: 0.1),
+              blurRadius: 15,
+              offset: const Offset(0, 5),
+            ),
+          ],
+          border: Border.all(
+            color: customColors?.success?.withValues(alpha: 0.5) ?? AppTheme.primaryColor,
+            width: 2,
+          ),
+        ),
+        padding: const EdgeInsets.all(24),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Respuesta correcta:',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                  color: customColors?.success ?? AppTheme.primaryColor,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              ...correctOptions.map(
+                (opt) => Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Text(
+                    opt,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ),
+              if (widget.question.explanation.isNotEmpty) ...[
+                const SizedBox(height: 24),
+                const Divider(),
+                const SizedBox(height: 16),
+                const Text(
+                  'Explicación:',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    color: Colors.grey,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  widget.question.explanation,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    height: 1.5,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ]
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: _flipCard,
+      child: AnimatedBuilder(
+        animation: _animation,
+        builder: (context, child) {
+          final isUnder = _animation.value > pi / 2;
+          return Transform(
+            alignment: Alignment.center,
+            transform: Matrix4.identity()
+              ..setEntry(3, 2, 0.001)
+              ..rotateY(_animation.value),
+            child: isUnder ? _buildBack() : _buildFront(),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/widgets/quiz_loaded_bottom_bar.dart
+++ b/lib/presentation/screens/widgets/quiz_loaded_bottom_bar.dart
@@ -28,6 +28,7 @@ class QuizLoadedBottomBar extends StatefulWidget {
   final VoidCallback onSave;
   final VoidCallback onDelete;
   final VoidCallback onPlay;
+  final VoidCallback onPlayFlashcards;
   final VoidCallback? onExportPdf;
   final bool isPlayEnabled;
   final int selectedQuestionCount;
@@ -45,6 +46,7 @@ class QuizLoadedBottomBar extends StatefulWidget {
     required this.onSave,
     required this.onDelete,
     required this.onPlay,
+    required this.onPlayFlashcards,
     required this.onDeleteDuplicates,
     this.onExportPdf,
     this.isPlayEnabled = false,
@@ -387,13 +389,31 @@ class _QuizLoadedBottomBarState extends State<QuizLoadedBottomBar> {
                         alignment: Alignment.center,
                         child: SizedBox(
                           width: effectiveWidth,
-                          child: QuizdyButton(
-                            title: localizations.startQuizButton,
-                            icon: LucideIcons.play,
-                            expanded: true,
-                            onPressed: widget.isPlayEnabled
-                                ? widget.onPlay
-                                : null,
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: QuizdyButton(
+                                  title: localizations.startFlashcardsButton,
+                                  icon: LucideIcons.layers,
+                                  expanded: true,
+                                  type: QuizdyButtonType.secondary,
+                                  onPressed: widget.isPlayEnabled
+                                      ? widget.onPlayFlashcards
+                                      : null,
+                                ),
+                              ),
+                              const SizedBox(width: gap),
+                              Expanded(
+                                child: QuizdyButton(
+                                  title: localizations.startQuizButton,
+                                  icon: LucideIcons.play,
+                                  expanded: true,
+                                  onPressed: widget.isPlayEnabled
+                                      ? widget.onPlay
+                                      : null,
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ),

--- a/lib/presentation/widgets/quizdy_latex_text.dart
+++ b/lib/presentation/widgets/quizdy_latex_text.dart
@@ -33,12 +33,16 @@ class QuizdyLatexText extends StatelessWidget {
   /// Text overflow behavior
   final TextOverflow overflow;
 
+  /// How the text should be aligned horizontally.
+  final TextAlign textAlign;
+
   const QuizdyLatexText(
     this.text, {
     super.key,
     this.style,
     this.maxLines,
     this.overflow = TextOverflow.clip,
+    this.textAlign = TextAlign.start,
   });
 
   @override
@@ -49,7 +53,13 @@ class QuizdyLatexText extends StatelessWidget {
         text.contains('\$') && text.indexOf('\$', text.indexOf('\$') + 1) != -1;
 
     if (!hasInline) {
-      return Text(text, style: style, maxLines: maxLines, overflow: overflow);
+      return Text(
+        text,
+        style: style,
+        maxLines: maxLines,
+        overflow: overflow,
+        textAlign: textAlign,
+      );
     }
 
     // Parse and render mixed LaTeX and plain text
@@ -58,6 +68,7 @@ class QuizdyLatexText extends StatelessWidget {
       style: style,
       maxLines: maxLines,
       overflow: overflow,
+      textAlign: textAlign,
     );
   }
 }
@@ -68,12 +79,14 @@ class _LaTeXRichText extends StatelessWidget {
   final TextStyle? style;
   final int? maxLines;
   final TextOverflow overflow;
+  final TextAlign textAlign;
 
   const _LaTeXRichText({
     required this.text,
     this.style,
     this.maxLines,
     this.overflow = TextOverflow.ellipsis,
+    this.textAlign = TextAlign.start,
   });
 
   @override
@@ -88,12 +101,14 @@ class _LaTeXRichText extends StatelessWidget {
         style: effectiveStyle,
         maxLines: maxLines,
         overflow: overflow,
+        textAlign: textAlign,
       );
     }
 
     return RichText(
       maxLines: maxLines,
       overflow: overflow,
+      textAlign: textAlign,
       text: TextSpan(children: spans, style: effectiveStyle),
     );
   }

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -24,6 +24,7 @@ import 'package:quizdy/presentation/screens/quiz_loaded_screen.dart';
 import 'package:quizdy/presentation/screens/quiz_file_execution_screen.dart';
 import 'package:quizdy/presentation/screens/study_editor/component_editor_screen.dart';
 import 'package:quizdy/presentation/screens/study_screen.dart';
+import 'package:quizdy/presentation/screens/flashcards_screen.dart';
 import 'package:quizdy/domain/models/ai/ai_difficulty_level.dart';
 import 'package:quizdy/domain/models/ai/ai_generation_mode.dart';
 
@@ -46,6 +47,7 @@ class AppRoutes {
   static const String quizFileExecutionScreen = '/quiz_file_execution_screen';
   static const String studyScreen = '/study_screen';
   static const String componentEditorScreen = '/component_editor_screen';
+  static const String flashcardsScreen = '/flashcards_screen';
 }
 
 GoRouter buildAppRouter({required bool showOnboarding}) => GoRouter(
@@ -118,6 +120,11 @@ GoRouter buildAppRouter({required bool showOnboarding}) => GoRouter(
           language: extra['language'] as String?,
         );
       },
+    ),
+    GoRoute(
+      path: AppRoutes.flashcardsScreen,
+      builder: (context, state) =>
+          FlashcardsScreen(quizFile: ServiceLocator.getIt<QuizFile>()),
     ),
   ],
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -326,6 +326,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.1.1"
+  flutter_card_swiper:
+    dependency: "direct main"
+    description:
+      name: flutter_card_swiper
+      sha256: "895c6974729b51cf73a35f1b58ab57a0af3293131319e2cbccac3bc57ffcd69f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   flutter_launcher_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   share_plus: ^12.0.2
   app_links: ^7.0.0
   in_app_update: ^4.2.3
+  flutter_card_swiper: ^7.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

This PR introduces a new **Flashcards Study Mode** to the application, leveraging the `flutter_card_swiper` package.

### Key Changes
*   **Added `FlashcardsScreen`**: A dedicated screen to study with flashcards.
*   **Added `FlashcardWidget`**: An interactive widget featuring a 3D flip animation to reveal correct answers and explanations.
*   **Stateful Study Queue**: Correctly swiped cards are removed, while incorrect cards are sent to the back of the queue for later review.
*   **Translations**: Generated and added localizations for all supported languages.
*   **UI Integration**: Added a secondary `Flashcards` button next to the `Start Quiz` button in the Quiz loaded bottom bar.


https://github.com/user-attachments/assets/c9b1144c-0ef3-4ab8-ad5a-2b0dbe58fd5d

