### PR TITLE
feature: Stats ordering with multiple options

### DIFF
--- a/lib/core/l10n/app_ar.arb
+++ b/lib/core/l10n/app_ar.arb
@@ -2875,5 +2875,13 @@
   "srsEmptyStateSubtitle": "أكمل جلسة الدراسة الأولى أو خذ امتحانًا لبدء تتبع تقدمك في التعلم.",
   "linkStudySection": "ربط بقسم الدراسة",
   "noStudySection": "بلا",
-  "confirmDeleteSectionWithQuestionsMessage": "هذا القسم يحتوي على أسئلة مرتبطة به. هل أنت متأكد أنك تريد حذف `{sectionName}`؟"
+  "confirmDeleteSectionWithQuestionsMessage": "هذا القسم يحتوي على أسئلة مرتبطة به. هل أنت متأكد أنك تريد حذف `{sectionName}`؟",
+  "srsSortTooltip": "ترتيب",
+  "srsSortByName": "الاسم (أ-ي)",
+  "srsSortBySectionOrder": "ترتيب الأقسام",
+  "srsSortByPendingQuestions": "الأسئلة المعلقة",
+  "srsSortByHitRate": "معدل الإجابة",
+  "srsSortAscending": "تصاعدي",
+  "srsSortDescending": "تنازلي",
+  "srsUnassignedSection": "غير مُعيَّن"
 }

--- a/lib/core/l10n/app_ca.arb
+++ b/lib/core/l10n/app_ca.arb
@@ -2563,5 +2563,13 @@
   "srsEmptyStateSubtitle": "Completa la teva primera sessió d'estudi o fes un examen per començar a registrar el teu progrés d'aprenentatge.",
   "linkStudySection": "Vincular a secció d'estudi",
   "noStudySection": "Cap",
-  "confirmDeleteSectionWithQuestionsMessage": "Aquesta secció té preguntes associades. Segur que vols eliminar `{sectionName}`?"
+  "confirmDeleteSectionWithQuestionsMessage": "Aquesta secció té preguntes associades. Segur que vols eliminar `{sectionName}`?",
+  "srsSortTooltip": "Ordenar",
+  "srsSortByName": "Nom (A-Z)",
+  "srsSortBySectionOrder": "Ordre de seccions",
+  "srsSortByPendingQuestions": "Preguntes pendents",
+  "srsSortByHitRate": "Taxa d'encerts",
+  "srsSortAscending": "Ascendent",
+  "srsSortDescending": "Descendent",
+  "srsUnassignedSection": "Sense secció"
 }

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -2557,5 +2557,13 @@
   "srsEmptyStateSubtitle": "Schließen Sie Ihre erste Lernsitzung ab oder nehmen Sie an einer Prüfung teil, um Ihren Lernfortschritt zu verfolgen.",
   "linkStudySection": "Mit Studienabschnitt verknüpfen",
   "noStudySection": "Keine",
-  "confirmDeleteSectionWithQuestionsMessage": "Dieser Bereich hat zugeordnete Fragen. Sind Sie sicher, dass Sie `{sectionName}` löschen möchten?"
+  "confirmDeleteSectionWithQuestionsMessage": "Dieser Bereich hat zugeordnete Fragen. Sind Sie sicher, dass Sie `{sectionName}` löschen möchten?",
+  "srsSortTooltip": "Sortieren",
+  "srsSortByName": "Name (A-Z)",
+  "srsSortBySectionOrder": "Abschnittsreihenfolge",
+  "srsSortByPendingQuestions": "Ausstehende Fragen",
+  "srsSortByHitRate": "Trefferquote",
+  "srsSortAscending": "Aufsteigend",
+  "srsSortDescending": "Absteigend",
+  "srsUnassignedSection": "Nicht zugewiesen"
 }

--- a/lib/core/l10n/app_el.arb
+++ b/lib/core/l10n/app_el.arb
@@ -1461,5 +1461,13 @@
   "srsEmptyStateSubtitle": "Ολοκληρώστε την πρώτη σας συνεδρία μελέτης ή κάντε μια εξέταση για να ξεκινήσετε να παρακολουθείτε την πρόοδό σας.",
   "linkStudySection": "Σύνδεση με ενότητα μελέτης",
   "noStudySection": "Κανένα",
-  "confirmDeleteSectionWithQuestionsMessage": "Αυτή η ενότητα έχει συσχετισμένες ερωτήσεις. Είστε βέβαιοι ότι θέλετε να διαγράψετε το `{sectionName}`;"
+  "confirmDeleteSectionWithQuestionsMessage": "Αυτή η ενότητα έχει συσχετισμένες ερωτήσεις. Είστε βέβαιοι ότι θέλετε να διαγράψετε το `{sectionName}`;",
+  "srsSortTooltip": "Ταξινόμηση",
+  "srsSortByName": "Όνομα (Α-Ω)",
+  "srsSortBySectionOrder": "Σειρά ενοτήτων",
+  "srsSortByPendingQuestions": "Εκκρεμείς ερωτήσεις",
+  "srsSortByHitRate": "Ποσοστό επιτυχίας",
+  "srsSortAscending": "Αύξουσα",
+  "srsSortDescending": "Φθίνουσα",
+  "srsUnassignedSection": "Χωρίς τμήμα"
 }

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -3129,5 +3129,44 @@
   "noStudySection": "None",
   "@noStudySection": {
     "description": "Option in the dropdown to not link the question to any study section"
+  },
+  "srsSortTooltip": "Sort",
+  "srsSortByName": "Name (A-Z)",
+  "srsSortBySectionOrder": "Section order",
+  "srsSortByPendingQuestions": "Pending questions",
+  "srsSortByHitRate": "Hit rate",
+  "srsSortAscending": "Ascending",
+  "srsSortDescending": "Descending",
+  "srsSortTooltip": "Sort",
+  "@srsSortTooltip": {
+    "description": "Tooltip for the sort button in SRS stats appbar"
+  },
+  "srsSortByName": "Name (A-Z)",
+  "@srsSortByName": {
+    "description": "Sort option: alphabetical by name"
+  },
+  "srsSortBySectionOrder": "Section order",
+  "@srsSortBySectionOrder": {
+    "description": "Sort option: original section order"
+  },
+  "srsSortByPendingQuestions": "Pending questions",
+  "@srsSortByPendingQuestions": {
+    "description": "Sort option: by number of pending (due) questions"
+  },
+  "srsSortByHitRate": "Hit rate",
+  "@srsSortByHitRate": {
+    "description": "Sort option: by hit rate percentage"
+  },
+  "srsSortAscending": "Ascending",
+  "@srsSortAscending": {
+    "description": "Sort direction: ascending"
+  },
+  "srsSortDescending": "Descending",
+  "@srsSortDescending": {
+    "description": "Sort direction: descending"
+  },
+  "srsUnassignedSection": "Unassigned",
+  "@srsUnassignedSection": {
+    "description": "Label shown when a question has no study section assigned"
   }
 }

--- a/lib/core/l10n/app_es.arb
+++ b/lib/core/l10n/app_es.arb
@@ -2731,5 +2731,13 @@
   "modeGeneratesStats": "Genera estadísticas SRS",
   "modeNoStats": "No genera estadísticas",
   "linkStudySection": "Vincular a sección de estudio",
-  "noStudySection": "Ninguna"
+  "noStudySection": "Ninguna",
+  "srsSortTooltip": "Ordenar",
+  "srsSortByName": "Nombre (A-Z)",
+  "srsSortBySectionOrder": "Orden de secciones",
+  "srsSortByPendingQuestions": "Preguntas pendientes",
+  "srsSortByHitRate": "Porcentaje de aciertos",
+  "srsSortAscending": "Ascendente",
+  "srsSortDescending": "Descendente",
+  "srsUnassignedSection": "Sin asignar"
 }

--- a/lib/core/l10n/app_eu.arb
+++ b/lib/core/l10n/app_eu.arb
@@ -2461,5 +2461,13 @@
   "srsEmptyStateSubtitle": "Bete zure lehenengo ikasketa saioa edo egin azterketa bat zure ikaskuntzaren aurrerapena jarraitzeko.",
   "linkStudySection": "Lotu ikasketa atalarekin",
   "noStudySection": "Bat ere ez",
-  "confirmDeleteSectionWithQuestionsMessage": "Atal honek lotutako galderak ditu. Ziur zaude `{sectionName}` ezabatu nahi duzula?"
+  "confirmDeleteSectionWithQuestionsMessage": "Atal honek lotutako galderak ditu. Ziur zaude `{sectionName}` ezabatu nahi duzula?",
+  "srsSortTooltip": "Ordenatu",
+  "srsSortByName": "Izena (A-Z)",
+  "srsSortBySectionOrder": "Atalaren ordena",
+  "srsSortByPendingQuestions": "Galdera irekiak",
+  "srsSortByHitRate": "Asmaketa-tasa",
+  "srsSortAscending": "Gorantz",
+  "srsSortDescending": "Beherantz",
+  "srsUnassignedSection": "Esleitu gabe"
 }

--- a/lib/core/l10n/app_fr.arb
+++ b/lib/core/l10n/app_fr.arb
@@ -2506,5 +2506,13 @@
   "srsEmptyStateSubtitle": "Terminez votre première session d'étude ou passez un examen pour commencer à suivre vos progrès.",
   "linkStudySection": "Lier à la section d'étude",
   "noStudySection": "Aucun",
-  "confirmDeleteSectionWithQuestionsMessage": "Cette section a des questions associées. Voulez-vous vraiment supprimer `{sectionName}` ?"
+  "confirmDeleteSectionWithQuestionsMessage": "Cette section a des questions associées. Voulez-vous vraiment supprimer `{sectionName}` ?",
+  "srsSortTooltip": "Trier",
+  "srsSortByName": "Nom (A-Z)",
+  "srsSortBySectionOrder": "Ordre des sections",
+  "srsSortByPendingQuestions": "Questions en attente",
+  "srsSortByHitRate": "Taux de réussite",
+  "srsSortAscending": "Croissant",
+  "srsSortDescending": "Décroissant",
+  "srsUnassignedSection": "Non attribué"
 }

--- a/lib/core/l10n/app_gl.arb
+++ b/lib/core/l10n/app_gl.arb
@@ -2461,5 +2461,13 @@
   "srsEmptyStateSubtitle": "Completa a túa primeira sesión de estudo ou fai un exame para comezar a rexistrar o teu progreso de aprendizaxe.",
   "linkStudySection": "Vincular a sección de estudo",
   "noStudySection": "Ningún",
-  "confirmDeleteSectionWithQuestionsMessage": "Esta sección ten preguntas asociadas. Seguro que queres eliminar `{sectionName}`?"
+  "confirmDeleteSectionWithQuestionsMessage": "Esta sección ten preguntas asociadas. Seguro que queres eliminar `{sectionName}`?",
+  "srsSortTooltip": "Ordenar",
+  "srsSortByName": "Nome (A-Z)",
+  "srsSortBySectionOrder": "Orde de seccións",
+  "srsSortByPendingQuestions": "Preguntas pendentes",
+  "srsSortByHitRate": "Taxa de acertos",
+  "srsSortAscending": "Ascendente",
+  "srsSortDescending": "Descendente",
+  "srsUnassignedSection": "Sen sección"
 }

--- a/lib/core/l10n/app_hi.arb
+++ b/lib/core/l10n/app_hi.arb
@@ -2464,5 +2464,13 @@
   "srsEmptyStateSubtitle": "अपनी पहली अध्ययन सत्र पूरा करें या अपनी सीखने की प्रगति को ट्रैक करना शुरू करने के लिए एक परीक्षा दें।",
   "linkStudySection": "अध्ययन अनुभाग से लिंक करें",
   "noStudySection": "कोई नहीं",
-  "confirmDeleteSectionWithQuestionsMessage": "इस अनुभाग में जुड़े हुए प्रश्न हैं। क्या आप वाकई `{sectionName}` को हटाना चाहते हैं?"
+  "confirmDeleteSectionWithQuestionsMessage": "इस अनुभाग में जुड़े हुए प्रश्न हैं। क्या आप वाकई `{sectionName}` को हटाना चाहते हैं?",
+  "srsSortTooltip": "क्रमबद्ध करें",
+  "srsSortByName": "नाम (A-Z)",
+  "srsSortBySectionOrder": "अनुभाग क्रम",
+  "srsSortByPendingQuestions": "लंबित प्रश्न",
+  "srsSortByHitRate": "सफलता दर",
+  "srsSortAscending": "आरोही",
+  "srsSortDescending": "अवरोही",
+  "srsUnassignedSection": "अनिर्धारित"
 }

--- a/lib/core/l10n/app_it.arb
+++ b/lib/core/l10n/app_it.arb
@@ -2515,5 +2515,13 @@
   "srsEmptyStateSubtitle": "Completa la tua prima sessione di studio o fai un esame per iniziare a monitorare i tuoi progressi di apprendimento.",
   "linkStudySection": "Collega alla sezione di studio",
   "noStudySection": "Nessuno",
-  "confirmDeleteSectionWithQuestionsMessage": "Questa sezione ha domande associate. Sei sicuro di voler eliminare `{sectionName}`?"
+  "confirmDeleteSectionWithQuestionsMessage": "Questa sezione ha domande associate. Sei sicuro di voler eliminare `{sectionName}`?",
+  "srsSortTooltip": "Ordina",
+  "srsSortByName": "Nome (A-Z)",
+  "srsSortBySectionOrder": "Ordine delle sezioni",
+  "srsSortByPendingQuestions": "Domande in sospeso",
+  "srsSortByHitRate": "Tasso di risposta",
+  "srsSortAscending": "Crescente",
+  "srsSortDescending": "Decrescente",
+  "srsUnassignedSection": "Non assegnato"
 }

--- a/lib/core/l10n/app_ja.arb
+++ b/lib/core/l10n/app_ja.arb
@@ -2464,5 +2464,13 @@
   "srsEmptyStateSubtitle": "学習の進捗を追跡し始めるには、最初の学習セッションを完了するか試験を受けてください。",
   "linkStudySection": "学習セクションにリンク",
   "noStudySection": "なし",
-  "confirmDeleteSectionWithQuestionsMessage": "このセクションには関連する問題があります。本当に `{sectionName}` を削除しますか？"
+  "confirmDeleteSectionWithQuestionsMessage": "このセクションには関連する問題があります。本当に `{sectionName}` を削除しますか？",
+  "srsSortTooltip": "並び替え",
+  "srsSortByName": "名前 (A-Z)",
+  "srsSortBySectionOrder": "セクション順",
+  "srsSortByPendingQuestions": "保留中の問題",
+  "srsSortByHitRate": "正解率",
+  "srsSortAscending": "昇順",
+  "srsSortDescending": "降順",
+  "srsUnassignedSection": "未割り当て"
 }

--- a/lib/core/l10n/app_ka.arb
+++ b/lib/core/l10n/app_ka.arb
@@ -1150,5 +1150,13 @@
   "srsEmptyStateSubtitle": "დაასრულეთ თქვენი პირველი სასწავლო სესია ან ჩააბარეთ გამოცდა, რათა დაიწყოთ თქვენი სასწავლო პროგრესის თვალყურის დევნება.",
   "linkStudySection": "სასწავლო სექციასთან დაკავშირება",
   "noStudySection": "არცერთი",
-  "confirmDeleteSectionWithQuestionsMessage": "ამ სექციასთან დაკავშირებულია კითხვები. ნამდვილად გსურთ წაშალოთ `{sectionName}`?"
+  "confirmDeleteSectionWithQuestionsMessage": "ამ სექციასთან დაკავშირებულია კითხვები. ნამდვილად გსურთ წაშალოთ `{sectionName}`?",
+  "srsSortTooltip": "დალაგება",
+  "srsSortByName": "სახელი (A-Z)",
+  "srsSortBySectionOrder": "განყოფილებების თანმიმდევრობა",
+  "srsSortByPendingQuestions": "მოლოდინი კითხვები",
+  "srsSortByHitRate": "სიზუსტის მაჩვენებელი",
+  "srsSortAscending": "ზრდადობით",
+  "srsSortDescending": "კლებადობით",
+  "srsUnassignedSection": "მინიჭებული არ არის"
 }

--- a/lib/core/l10n/app_ko.arb
+++ b/lib/core/l10n/app_ko.arb
@@ -1150,5 +1150,13 @@
   "srsEmptyStateSubtitle": "학습 진행 상황 추적을 시작하려면 첫 번째 학습 세션을 완료하거나 시험을 치르세요.",
   "linkStudySection": "학습 섹션에 연결",
   "noStudySection": "없음",
-  "confirmDeleteSectionWithQuestionsMessage": "이 섹션에 연결된 질문이 있습니다. 정말로 `{sectionName}`을(를) 삭제하시겠습니까?"
+  "confirmDeleteSectionWithQuestionsMessage": "이 섹션에 연결된 질문이 있습니다. 정말로 `{sectionName}`을(를) 삭제하시겠습니까?",
+  "srsSortTooltip": "정렬",
+  "srsSortByName": "이름 (A-Z)",
+  "srsSortBySectionOrder": "섹션 순서",
+  "srsSortByPendingQuestions": "미결 질문",
+  "srsSortByHitRate": "정답률",
+  "srsSortAscending": "오름차순",
+  "srsSortDescending": "내림차순",
+  "srsUnassignedSection": "미지정"
 }

--- a/lib/core/l10n/app_pt.arb
+++ b/lib/core/l10n/app_pt.arb
@@ -2552,5 +2552,13 @@
   "srsEmptyStateSubtitle": "Conclua sua primeira sessão de estudo ou faça um exame para começar a acompanhar seu progresso de aprendizado.",
   "linkStudySection": "Vincular à seção de estudo",
   "noStudySection": "Nenhum",
-  "confirmDeleteSectionWithQuestionsMessage": "Esta seção possui perguntas associadas. Tem certeza de que deseja excluir `{sectionName}`?"
+  "confirmDeleteSectionWithQuestionsMessage": "Esta seção possui perguntas associadas. Tem certeza de que deseja excluir `{sectionName}`?",
+  "srsSortTooltip": "Ordenar",
+  "srsSortByName": "Nome (A-Z)",
+  "srsSortBySectionOrder": "Ordem das secções",
+  "srsSortByPendingQuestions": "Perguntas pendentes",
+  "srsSortByHitRate": "Taxa de acertos",
+  "srsSortAscending": "Crescente",
+  "srsSortDescending": "Decrescente",
+  "srsUnassignedSection": "Sem secção"
 }

--- a/lib/core/l10n/app_ru.arb
+++ b/lib/core/l10n/app_ru.arb
@@ -1165,5 +1165,13 @@
   "srsEmptyStateSubtitle": "Завершите свою первую учебную сессию или сдайте экзамен, чтобы начать отслеживать свой прогрес в обучении.",
   "linkStudySection": "Связать с разделом обучения",
   "noStudySection": "Нет",
-  "confirmDeleteSectionWithQuestionsMessage": "С этим разделом связаны вопросы. Вы действительно хотите удалить `{sectionName}`?"
+  "confirmDeleteSectionWithQuestionsMessage": "С этим разделом связаны вопросы. Вы действительно хотите удалить `{sectionName}`?",
+  "srsSortTooltip": "Сортировка",
+  "srsSortByName": "Имя (А-Я)",
+  "srsSortBySectionOrder": "Порядок разделов",
+  "srsSortByPendingQuestions": "Ожидающие вопросы",
+  "srsSortByHitRate": "Процент успеха",
+  "srsSortAscending": "По возрастанию",
+  "srsSortDescending": "По убыванию",
+  "srsUnassignedSection": "Без раздела"
 }

--- a/lib/core/l10n/app_uk.arb
+++ b/lib/core/l10n/app_uk.arb
@@ -1183,5 +1183,13 @@
   "srsEmptyStateSubtitle": "Завершіть свою першу навчальну сесію або складіть іспит, щоб почати відстежувати свій прогрес у навчанні.",
   "linkStudySection": "Зв'язати з розділом навчання",
   "noStudySection": "Немає",
-  "confirmDeleteSectionWithQuestionsMessage": "З цим розділом пов'язані питання. Ви дійсно хочете видалити `{sectionName}`?"
+  "confirmDeleteSectionWithQuestionsMessage": "З цим розділом пов'язані питання. Ви дійсно хочете видалити `{sectionName}`?",
+  "srsSortTooltip": "Сортування",
+  "srsSortByName": "Ім'я (А-Я)",
+  "srsSortBySectionOrder": "Порядок розділів",
+  "srsSortByPendingQuestions": "Очікувані питання",
+  "srsSortByHitRate": "Відсоток успіху",
+  "srsSortAscending": "За зростанням",
+  "srsSortDescending": "За спаданням",
+  "srsUnassignedSection": "Без розділу"
 }

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -2513,5 +2513,13 @@
   "srsEmptyStateSubtitle": "完成您的第一个学习会话或参加考试以开始跟踪您的学习进度。",
   "linkStudySection": "链接至学习章节",
   "noStudySection": "无",
-  "confirmDeleteSectionWithQuestionsMessage": "此章节包含关联问题。您确定要删除 `{sectionName}` 吗？"
+  "confirmDeleteSectionWithQuestionsMessage": "此章节包含关联问题。您确定要删除 `{sectionName}` 吗？",
+  "srsSortTooltip": "排序",
+  "srsSortByName": "名称 (A-Z)",
+  "srsSortBySectionOrder": "章节顺序",
+  "srsSortByPendingQuestions": "待复习题目",
+  "srsSortByHitRate": "正确率",
+  "srsSortAscending": "升序",
+  "srsSortDescending": "降序",
+  "srsUnassignedSection": "未分配"
 }

--- a/lib/domain/models/srs/srs_metadata.dart
+++ b/lib/domain/models/srs/srs_metadata.dart
@@ -47,6 +47,9 @@ class SrsMetadata extends HiveObject {
   @HiveField(8)
   String questionText;
 
+  @HiveField(9)
+  String? sectionName;
+
   SrsMetadata({
     required this.questionIdentity,
     required this.fileIdentifier,
@@ -57,6 +60,7 @@ class SrsMetadata extends HiveObject {
     this.timesCorrect = 0,
     this.timesIncorrect = 0,
     this.questionText = '',
+    this.sectionName,
   }) : nextReviewDate = nextReviewDate ?? DateTime.now();
 
   /// Creates a copy of the `SrsMetadata` with optional parameter modifications.
@@ -70,6 +74,7 @@ class SrsMetadata extends HiveObject {
     int? timesCorrect,
     int? timesIncorrect,
     String? questionText,
+    String? sectionName,
   }) {
     return SrsMetadata(
       questionIdentity: questionIdentity ?? this.questionIdentity,
@@ -81,6 +86,7 @@ class SrsMetadata extends HiveObject {
       timesCorrect: timesCorrect ?? this.timesCorrect,
       timesIncorrect: timesIncorrect ?? this.timesIncorrect,
       questionText: questionText ?? this.questionText,
+      sectionName: sectionName ?? this.sectionName,
     );
   }
 }

--- a/lib/presentation/blocs/quiz_execution_bloc/quiz_execution_bloc.dart
+++ b/lib/presentation/blocs/quiz_execution_bloc/quiz_execution_bloc.dart
@@ -46,6 +46,7 @@ class QuizExecutionBloc extends Bloc<QuizExecutionEvent, QuizExecutionState> {
           userAnswers: {},
           quizConfig: event.quizConfig,
           fileIdentifier: event.fileIdentifier,
+          studySectionNames: event.studySectionNames,
         ),
       );
     });
@@ -398,10 +399,15 @@ class QuizExecutionBloc extends Bloc<QuizExecutionEvent, QuizExecutionState> {
         final score = isCorrect
             ? 4
             : 1; // Map correct to 4, incorrect to 1 for SM-2
+        String? sectionName;
+        final sectionId = question.studySectionId;
+        if (sectionId != null) {
+          sectionName = currentState.studySectionNames?[sectionId];
+        }
         final updatedMetadata = AnkiAlgorithmService.calculateNextReview(
           metadata,
           score,
-        ).copyWith(questionText: question.text);
+        ).copyWith(questionText: question.text, sectionName: sectionName);
         await srsRepository!.saveMetadata(updatedMetadata);
       }
     }

--- a/lib/presentation/blocs/quiz_execution_bloc/quiz_execution_event.dart
+++ b/lib/presentation/blocs/quiz_execution_bloc/quiz_execution_event.dart
@@ -27,10 +27,14 @@ class QuizExecutionStarted extends QuizExecutionEvent {
   final QuizConfig quizConfig;
   final String? fileIdentifier;
 
+  /// Maps studySectionId → section title for enriching SRS metadata.
+  final Map<String, String>? studySectionNames;
+
   QuizExecutionStarted(
     this.questions, {
     required this.quizConfig,
     this.fileIdentifier,
+    this.studySectionNames,
   });
 }
 

--- a/lib/presentation/blocs/quiz_execution_bloc/quiz_execution_state.dart
+++ b/lib/presentation/blocs/quiz_execution_bloc/quiz_execution_state.dart
@@ -54,6 +54,9 @@ class QuizExecutionInProgress extends QuizExecutionState {
   final bool wasLimitReached;
   final String? fileIdentifier;
 
+  /// Maps studySectionId → section title, used to enrich SRS metadata on save.
+  final Map<String, String>? studySectionNames;
+
   QuizExecutionInProgress({
     required this.questions,
     required this.currentQuestionIndex,
@@ -63,6 +66,7 @@ class QuizExecutionInProgress extends QuizExecutionState {
     this.isAiEvaluating = false,
     this.wasLimitReached = false,
     this.fileIdentifier,
+    this.studySectionNames,
     Map<int, String>? essayAnswers,
     Set<int>? validatedQuestions,
     Map<int, EssayAiEvaluation>? aiEvaluations,
@@ -140,6 +144,7 @@ class QuizExecutionInProgress extends QuizExecutionState {
     bool? isAiEvaluating,
     bool? wasLimitReached,
     String? fileIdentifier,
+    Map<String, String>? studySectionNames,
   }) {
     return QuizExecutionInProgress(
       questions: questions ?? this.questions,
@@ -154,6 +159,7 @@ class QuizExecutionInProgress extends QuizExecutionState {
       isAiEvaluating: isAiEvaluating ?? this.isAiEvaluating,
       wasLimitReached: wasLimitReached ?? this.wasLimitReached,
       fileIdentifier: fileIdentifier ?? this.fileIdentifier,
+      studySectionNames: studySectionNames ?? this.studySectionNames,
     );
   }
 }

--- a/lib/presentation/screens/quiz_file_execution_screen.dart
+++ b/lib/presentation/screens/quiz_file_execution_screen.dart
@@ -131,8 +131,9 @@ class _QuizFileExecutionScreenState extends State<QuizFileExecutionScreen> {
                     fileIdentifier:
                         widget.quizFile.filePath ??
                         widget.quizFile.metadata.title,
-                    studySectionNames:
-                        studySectionNames.isEmpty ? null : studySectionNames,
+                    studySectionNames: studySectionNames.isEmpty
+                        ? null
+                        : studySectionNames,
                   ),
                 );
               },

--- a/lib/presentation/screens/quiz_file_execution_screen.dart
+++ b/lib/presentation/screens/quiz_file_execution_screen.dart
@@ -118,6 +118,12 @@ class _QuizFileExecutionScreenState extends State<QuizFileExecutionScreen> {
                       isStudyMode: false,
                     );
 
+                final studySectionNames = <String, String>{
+                  for (final chunk
+                      in widget.quizFile.study?.content.cache ?? [])
+                    chunk.id: chunk.title,
+                };
+
                 return ServiceLocator.getIt<QuizExecutionBloc>()..add(
                   QuizExecutionStarted(
                     questionsToUse,
@@ -125,6 +131,8 @@ class _QuizFileExecutionScreenState extends State<QuizFileExecutionScreen> {
                     fileIdentifier:
                         widget.quizFile.filePath ??
                         widget.quizFile.metadata.title,
+                    studySectionNames:
+                        studySectionNames.isEmpty ? null : studySectionNames,
                   ),
                 );
               },

--- a/lib/presentation/screens/srs/srs_stats_screen.dart
+++ b/lib/presentation/screens/srs/srs_stats_screen.dart
@@ -67,9 +67,9 @@ class _SrsStatsScreenState extends State<SrsStatsScreen> {
         case _SrsSortField.sectionOrder:
           comparison = 0;
         case _SrsSortField.name:
-          comparison = a.questionText
-              .toLowerCase()
-              .compareTo(b.questionText.toLowerCase());
+          comparison = a.questionText.toLowerCase().compareTo(
+            b.questionText.toLowerCase(),
+          );
         case _SrsSortField.pendingQuestions:
           // Earlier nextReviewDate → more urgent → comes first in ascending.
           comparison = a.nextReviewDate.compareTo(b.nextReviewDate);
@@ -91,10 +91,9 @@ class _SrsStatsScreenState extends State<SrsStatsScreen> {
   void _onSortFieldSelected(_SrsSortField field) {
     setState(() {
       if (_sortField == field) {
-        _sortDirection =
-            _sortDirection == _SrsSortDirection.ascending
-                ? _SrsSortDirection.descending
-                : _SrsSortDirection.ascending;
+        _sortDirection = _sortDirection == _SrsSortDirection.ascending
+            ? _SrsSortDirection.descending
+            : _SrsSortDirection.ascending;
       } else {
         _sortField = field;
         _sortDirection = _SrsSortDirection.ascending;
@@ -117,43 +116,38 @@ class _SrsStatsScreenState extends State<SrsStatsScreen> {
           ),
         ),
         onLeadingPressed: () => context.pop(),
-        actions:
-            _groupedStats.isEmpty
-                ? null
-                : [
-                  _SortMenuButton(
-                    sortField: _sortField,
-                    sortDirection: _sortDirection,
-                    onSelected: _onSortFieldSelected,
-                  ),
-                  _AppBarActionButton(
-                    icon: Icons.restart_alt,
-                    tooltip: l10n.srsResetAllStatsTooltip,
-                    onPressed: () => _confirmDeleteAll(context),
-                  ),
-                ],
-      ),
-      body:
-          _groupedStats.isEmpty
-              ? const SrsEmptyState()
-              : ListView.builder(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 20,
+        actions: _groupedStats.isEmpty
+            ? null
+            : [
+                _SortMenuButton(
+                  sortField: _sortField,
+                  sortDirection: _sortDirection,
+                  onSelected: _onSortFieldSelected,
                 ),
-                itemCount: _groupedStats.length,
-                itemBuilder: (context, index) {
-                  final fileId = _groupedStats.keys.elementAt(index);
-                  final stats = _sortedStats(_groupedStats[fileId]!);
-                  return SrsFileStatsCard(
-                    key: ValueKey(fileId),
-                    fileId: fileId,
-                    stats: stats,
-                    onReset: () => _confirmResetFile(context, fileId),
-                    onDelete: () => _confirmDeleteFile(context, fileId),
-                  );
-                },
-              ),
+                _AppBarActionButton(
+                  icon: Icons.restart_alt,
+                  tooltip: l10n.srsResetAllStatsTooltip,
+                  onPressed: () => _confirmDeleteAll(context),
+                ),
+              ],
+      ),
+      body: _groupedStats.isEmpty
+          ? const SrsEmptyState()
+          : ListView.builder(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+              itemCount: _groupedStats.length,
+              itemBuilder: (context, index) {
+                final fileId = _groupedStats.keys.elementAt(index);
+                final stats = _sortedStats(_groupedStats[fileId]!);
+                return SrsFileStatsCard(
+                  key: ValueKey(fileId),
+                  fileId: fileId,
+                  stats: stats,
+                  onReset: () => _confirmResetFile(context, fileId),
+                  onDelete: () => _confirmDeleteFile(context, fileId),
+                );
+              },
+            ),
     );
   }
 
@@ -200,27 +194,26 @@ class _SrsStatsScreenState extends State<SrsStatsScreen> {
     final l10n = AppLocalizations.of(context)!;
     showDialog(
       context: context,
-      builder:
-          (ctx) => AlertDialog(
-            title: Text(title),
-            content: Text(content),
-            actions: [
-              TextButton(
-                onPressed: () => context.pop(ctx),
-                child: Text(l10n.cancelButton.toUpperCase()),
-              ),
-              TextButton(
-                onPressed: () async {
-                  await onConfirm();
-                  if (ctx.mounted) {
-                    _loadStats();
-                    context.pop(ctx);
-                  }
-                },
-                child: Text(confirmLabel.toUpperCase()),
-              ),
-            ],
+      builder: (ctx) => AlertDialog(
+        title: Text(title),
+        content: Text(content),
+        actions: [
+          TextButton(
+            onPressed: () => context.pop(ctx),
+            child: Text(l10n.cancelButton.toUpperCase()),
           ),
+          TextButton(
+            onPressed: () async {
+              await onConfirm();
+              if (ctx.mounted) {
+                _loadStats();
+                context.pop(ctx);
+              }
+            },
+            child: Text(confirmLabel.toUpperCase()),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -273,10 +266,9 @@ class _SortMenuButton extends StatelessWidget {
     required this.onSelected,
   });
 
-  IconData get _directionIcon =>
-      sortDirection == _SrsSortDirection.ascending
-          ? LucideIcons.arrowUp
-          : LucideIcons.arrowDown;
+  IconData get _directionIcon => sortDirection == _SrsSortDirection.ascending
+      ? LucideIcons.arrowUp
+      : LucideIcons.arrowDown;
 
   @override
   Widget build(BuildContext context) {
@@ -303,42 +295,38 @@ class _SortMenuButton extends StatelessWidget {
         tooltip: l10n.srsSortTooltip,
         icon: Icon(LucideIcons.arrowUpDown, color: onPrimary, size: 20),
         onSelected: onSelected,
-        itemBuilder:
-            (context) =>
-                fields.map((entry) {
-                  final (field, label) = entry;
-                  final isSelected = sortField == field;
-                  return PopupMenuItem<_SrsSortField>(
-                    value: field,
-                    child: Row(
-                      children: [
-                        Icon(
-                          isSelected ? _directionIcon : LucideIcons.minus,
-                          size: 16,
-                          color:
-                              isSelected
-                                  ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).colorScheme.onSurface
-                                      .withValues(alpha: 0.3),
-                        ),
-                        const SizedBox(width: 10),
-                        Text(
-                          label,
-                          style: TextStyle(
-                            fontWeight:
-                                isSelected
-                                    ? FontWeight.w600
-                                    : FontWeight.normal,
-                            color:
-                                isSelected
-                                    ? Theme.of(context).colorScheme.primary
-                                    : null,
-                          ),
-                        ),
-                      ],
-                    ),
-                  );
-                }).toList(),
+        itemBuilder: (context) => fields.map((entry) {
+          final (field, label) = entry;
+          final isSelected = sortField == field;
+          return PopupMenuItem<_SrsSortField>(
+            value: field,
+            child: Row(
+              children: [
+                Icon(
+                  isSelected ? _directionIcon : LucideIcons.minus,
+                  size: 16,
+                  color: isSelected
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(
+                          context,
+                        ).colorScheme.onSurface.withValues(alpha: 0.3),
+                ),
+                const SizedBox(width: 10),
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontWeight: isSelected
+                        ? FontWeight.w600
+                        : FontWeight.normal,
+                    color: isSelected
+                        ? Theme.of(context).colorScheme.primary
+                        : null,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }).toList(),
       ),
     );
   }

--- a/lib/presentation/screens/srs/srs_stats_screen.dart
+++ b/lib/presentation/screens/srs/srs_stats_screen.dart
@@ -15,6 +15,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/core/service_locator.dart';
 import 'package:quizdy/core/theme/extensions/quiz_loaded_theme.dart';
@@ -23,6 +24,10 @@ import 'package:quizdy/domain/models/srs/srs_metadata.dart';
 import 'package:quizdy/presentation/screens/widgets/common/quizdy_app_bar.dart';
 import 'package:quizdy/presentation/screens/widgets/srs/srs_empty_state.dart';
 import 'package:quizdy/presentation/screens/widgets/srs/srs_file_stats_card.dart';
+
+enum _SrsSortField { sectionOrder, name, pendingQuestions, hitRate }
+
+enum _SrsSortDirection { ascending, descending }
 
 class SrsStatsScreen extends StatefulWidget {
   const SrsStatsScreen({super.key});
@@ -34,6 +39,8 @@ class SrsStatsScreen extends StatefulWidget {
 class _SrsStatsScreenState extends State<SrsStatsScreen> {
   late SrsRepository _srsRepository;
   Map<String, List<SrsMetadata>> _groupedStats = {};
+  _SrsSortField _sortField = _SrsSortField.sectionOrder;
+  _SrsSortDirection _sortDirection = _SrsSortDirection.ascending;
 
   @override
   void initState() {
@@ -45,6 +52,53 @@ class _SrsStatsScreenState extends State<SrsStatsScreen> {
   void _loadStats() {
     setState(() {
       _groupedStats = _srsRepository.getStatsGroupedByFile();
+    });
+  }
+
+  /// Returns [stats] sorted according to the current [_sortField] and
+  /// [_sortDirection]. A copy is always returned to avoid mutating the cache.
+  List<SrsMetadata> _sortedStats(List<SrsMetadata> stats) {
+    if (_sortField == _SrsSortField.sectionOrder) return List.of(stats);
+
+    final sorted = List.of(stats);
+    sorted.sort((a, b) {
+      final int comparison;
+      switch (_sortField) {
+        case _SrsSortField.sectionOrder:
+          comparison = 0;
+        case _SrsSortField.name:
+          comparison = a.questionText
+              .toLowerCase()
+              .compareTo(b.questionText.toLowerCase());
+        case _SrsSortField.pendingQuestions:
+          // Earlier nextReviewDate → more urgent → comes first in ascending.
+          comparison = a.nextReviewDate.compareTo(b.nextReviewDate);
+        case _SrsSortField.hitRate:
+          comparison = _retentionRate(a).compareTo(_retentionRate(b));
+      }
+      return _sortDirection == _SrsSortDirection.ascending
+          ? comparison
+          : -comparison;
+    });
+    return sorted;
+  }
+
+  double _retentionRate(SrsMetadata s) {
+    final total = s.timesCorrect + s.timesIncorrect;
+    return total > 0 ? s.timesCorrect / total * 100 : 0.0;
+  }
+
+  void _onSortFieldSelected(_SrsSortField field) {
+    setState(() {
+      if (_sortField == field) {
+        _sortDirection =
+            _sortDirection == _SrsSortDirection.ascending
+                ? _SrsSortDirection.descending
+                : _SrsSortDirection.ascending;
+      } else {
+        _sortField = field;
+        _sortDirection = _SrsSortDirection.ascending;
+      }
     });
   }
 
@@ -63,32 +117,43 @@ class _SrsStatsScreenState extends State<SrsStatsScreen> {
           ),
         ),
         onLeadingPressed: () => context.pop(),
-        actions: _groupedStats.isEmpty
-            ? null
-            : [
-                _AppBarActionButton(
-                  icon: Icons.restart_alt,
-                  tooltip: l10n.srsResetAllStatsTooltip,
-                  onPressed: () => _confirmDeleteAll(context),
-                ),
-              ],
+        actions:
+            _groupedStats.isEmpty
+                ? null
+                : [
+                  _SortMenuButton(
+                    sortField: _sortField,
+                    sortDirection: _sortDirection,
+                    onSelected: _onSortFieldSelected,
+                  ),
+                  _AppBarActionButton(
+                    icon: Icons.restart_alt,
+                    tooltip: l10n.srsResetAllStatsTooltip,
+                    onPressed: () => _confirmDeleteAll(context),
+                  ),
+                ],
       ),
-      body: _groupedStats.isEmpty
-          ? const SrsEmptyState()
-          : ListView.builder(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
-              itemCount: _groupedStats.length,
-              itemBuilder: (context, index) {
-                final fileId = _groupedStats.keys.elementAt(index);
-                final stats = _groupedStats[fileId]!;
-                return SrsFileStatsCard(
-                  fileId: fileId,
-                  stats: stats,
-                  onReset: () => _confirmResetFile(context, fileId),
-                  onDelete: () => _confirmDeleteFile(context, fileId),
-                );
-              },
-            ),
+      body:
+          _groupedStats.isEmpty
+              ? const SrsEmptyState()
+              : ListView.builder(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 20,
+                ),
+                itemCount: _groupedStats.length,
+                itemBuilder: (context, index) {
+                  final fileId = _groupedStats.keys.elementAt(index);
+                  final stats = _sortedStats(_groupedStats[fileId]!);
+                  return SrsFileStatsCard(
+                    key: ValueKey(fileId),
+                    fileId: fileId,
+                    stats: stats,
+                    onReset: () => _confirmResetFile(context, fileId),
+                    onDelete: () => _confirmDeleteFile(context, fileId),
+                  );
+                },
+              ),
     );
   }
 
@@ -135,29 +200,32 @@ class _SrsStatsScreenState extends State<SrsStatsScreen> {
     final l10n = AppLocalizations.of(context)!;
     showDialog(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(title),
-        content: Text(content),
-        actions: [
-          TextButton(
-            onPressed: () => context.pop(ctx),
-            child: Text(l10n.cancelButton.toUpperCase()),
+      builder:
+          (ctx) => AlertDialog(
+            title: Text(title),
+            content: Text(content),
+            actions: [
+              TextButton(
+                onPressed: () => context.pop(ctx),
+                child: Text(l10n.cancelButton.toUpperCase()),
+              ),
+              TextButton(
+                onPressed: () async {
+                  await onConfirm();
+                  if (ctx.mounted) {
+                    _loadStats();
+                    context.pop(ctx);
+                  }
+                },
+                child: Text(confirmLabel.toUpperCase()),
+              ),
+            ],
           ),
-          TextButton(
-            onPressed: () async {
-              await onConfirm();
-              if (ctx.mounted) {
-                _loadStats();
-                context.pop(ctx);
-              }
-            },
-            child: Text(confirmLabel.toUpperCase()),
-          ),
-        ],
-      ),
     );
   }
 }
+
+// ── AppBar widgets ────────────────────────────────────────────────────────────
 
 class _AppBarActionButton extends StatelessWidget {
   final IconData icon;
@@ -189,6 +257,88 @@ class _AppBarActionButton extends StatelessWidget {
           size: 20,
         ),
         tooltip: tooltip,
+      ),
+    );
+  }
+}
+
+class _SortMenuButton extends StatelessWidget {
+  final _SrsSortField sortField;
+  final _SrsSortDirection sortDirection;
+  final ValueChanged<_SrsSortField> onSelected;
+
+  const _SortMenuButton({
+    required this.sortField,
+    required this.sortDirection,
+    required this.onSelected,
+  });
+
+  IconData get _directionIcon =>
+      sortDirection == _SrsSortDirection.ascending
+          ? LucideIcons.arrowUp
+          : LucideIcons.arrowDown;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final onPrimary = Theme.of(context).colorScheme.onPrimary;
+
+    final fields = [
+      (_SrsSortField.sectionOrder, l10n.srsSortBySectionOrder),
+      (_SrsSortField.name, l10n.srsSortByName),
+      (_SrsSortField.pendingQuestions, l10n.srsSortByPendingQuestions),
+      (_SrsSortField.hitRate, l10n.srsSortByHitRate),
+    ];
+
+    return Container(
+      width: 40,
+      height: 40,
+      margin: const EdgeInsets.only(right: 8),
+      decoration: BoxDecoration(
+        color: context.quizLoadedTheme.appBarIconBackgroundColor,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: PopupMenuButton<_SrsSortField>(
+        padding: EdgeInsets.zero,
+        tooltip: l10n.srsSortTooltip,
+        icon: Icon(LucideIcons.arrowUpDown, color: onPrimary, size: 20),
+        onSelected: onSelected,
+        itemBuilder:
+            (context) =>
+                fields.map((entry) {
+                  final (field, label) = entry;
+                  final isSelected = sortField == field;
+                  return PopupMenuItem<_SrsSortField>(
+                    value: field,
+                    child: Row(
+                      children: [
+                        Icon(
+                          isSelected ? _directionIcon : LucideIcons.minus,
+                          size: 16,
+                          color:
+                              isSelected
+                                  ? Theme.of(context).colorScheme.primary
+                                  : Theme.of(context).colorScheme.onSurface
+                                      .withValues(alpha: 0.3),
+                        ),
+                        const SizedBox(width: 10),
+                        Text(
+                          label,
+                          style: TextStyle(
+                            fontWeight:
+                                isSelected
+                                    ? FontWeight.w600
+                                    : FontWeight.normal,
+                            color:
+                                isSelected
+                                    ? Theme.of(context).colorScheme.primary
+                                    : null,
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }).toList(),
       ),
     );
   }

--- a/lib/presentation/screens/widgets/srs/srs_question_row.dart
+++ b/lib/presentation/screens/widgets/srs/srs_question_row.dart
@@ -56,6 +56,25 @@ class SrsQuestionRow extends StatelessWidget {
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
           ),
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              Icon(LucideIcons.tag, size: 11, color: subtitleColor),
+              const SizedBox(width: 4),
+              Text(
+                stat.sectionName ?? l10n.srsUnassignedSection,
+                style: TextStyle(
+                  fontSize: 11,
+                  color: subtitleColor,
+                  fontStyle: stat.sectionName == null
+                      ? FontStyle.italic
+                      : FontStyle.normal,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
           const SizedBox(height: 6),
           Wrap(
             spacing: 14,


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                         
  - Added a global sort configuration to the SRS Stats screen (AppBar popup menu) that orders the questions inside each file card by: **question name (A-Z)**, **section order** (original), **pending questions** (Anki 
  due date), or **hit rate** — each with ascending/descending toggle.                                                                                                                                                    
  - Added a `sectionName` field to `SrsMetadata` (Hive field 9, nullable, backwards-compatible) that is persisted when a quiz is completed, so each question row in the stats card shows its study section name (or      
  *"Unassigned"* if none is linked).
 - Closes: #411                                                                                                                                                                                      
                                                                                                                                                                                                                         
  ## Changes                                                                                                                                                                                                             
                                                                                                                                                                                                                         
  ### Domain                                                                                                                                                                                                           
  - `lib/domain/models/srs/srs_metadata.dart` — added `String? sectionName` (`@HiveField(9)`) and updated `copyWith`.                                                                                                    
  - `lib/domain/models/srs/srs_metadata.g.dart` — updated Hive adapter to read/write 10 fields (field 9 = `sectionName`).                                                                                                
                                                                                                                                                                                                                         
  ### State management                                                                                                                                                                                                   
  - `lib/presentation/blocs/quiz_execution_bloc/quiz_execution_event.dart` — added `Map<String, String>? studySectionNames` to `QuizExecutionStarted`.                                                                   
  - `lib/presentation/blocs/quiz_execution_bloc/quiz_execution_state.dart` — added `Map<String, String>? studySectionNames` to `QuizExecutionInProgress` and its `copyWith`.                                             
  - `lib/presentation/blocs/quiz_execution_bloc/quiz_execution_bloc.dart` — propagates `studySectionNames` from event to state; resolves and saves `sectionName` per question on quiz completion.                        
                                                                                                                                                                                                                         
  ### Screens                                                                                                                                                                                                            
  - `lib/presentation/screens/quiz_file_execution_screen.dart` — builds `studySectionNames` map (`studySectionId → chunk.title`) from `quizFile.study.content.cache` and passes it to `QuizExecutionStarted`.            
  - `lib/presentation/screens/srs/srs_stats_screen.dart` — added `_SrsSortField` / `_SrsSortDirection` enums, `_sortedStats()` method, and `_SortMenuButton` AppBar widget with a `PopupMenuButton` matching the existing
   icon-button style.                                                                                                                                                                                                    
                                                                                                                                                                                                                         
  ### Widgets                                                                                                                                                                                                            
  - `lib/presentation/screens/widgets/srs/srs_question_row.dart` — displays a tag icon + section name below the question title; falls back to localised *"Unassigned"* label in italic when `sectionName` is `null`.     
                                                                                                                                                                                                                         
  ### Localisation                                                                                                                                                                                                       
  - Added 8 new keys (`srsSortTooltip`, `srsSortByName`, `srsSortBySectionOrder`, `srsSortByPendingQuestions`, `srsSortByHitRate`, `srsSortAscending`, `srsSortDescending`, `srsUnassignedSection`) to all 18 supported  
  locale ARB files with proper translations. 