### PR TITLE
feat(ai): migrate to Genkit Dart SDK and support dynamic model loading

### DIFF
--- a/lib/core/service_locator.dart
+++ b/lib/core/service_locator.dart
@@ -18,6 +18,7 @@ import 'package:get_it/get_it.dart';
 import 'package:quizdy/data/interceptors/ai_logging_interceptor.dart';
 import 'package:quizdy/data/interceptors/connectivity_interceptor.dart';
 import 'package:quizdy/data/repositories/ai/ai_repository_factory.dart';
+import 'package:quizdy/domain/models/ai/ai_model_catalog.dart';
 import 'package:quizdy/data/services/ai/ai_document_chunking_service.dart';
 import 'package:quizdy/data/services/ai/ai_jit_processing_service.dart';
 import 'package:quizdy/data/services/ai/ai_question_generation_service.dart';
@@ -123,6 +124,14 @@ class ServiceLocator {
         aiRepositoryFactory: getIt.get<AiRepositoryFactory>(),
         srsRepository: getIt.get<SrsRepository>(),
       ),
+    );
+
+    // Load dynamic models at startup if API keys are configured
+    final geminiKey = await configurationService.getGeminiApiKey();
+    final openaiKey = await configurationService.getOpenAIApiKey();
+    await AiModelCatalog.loadDynamicModels(
+      geminiApiKey: geminiKey,
+      openaiApiKey: openaiKey,
     );
   }
 

--- a/lib/data/repositories/ai/gemini_repository.dart
+++ b/lib/data/repositories/ai/gemini_repository.dart
@@ -17,6 +17,8 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
 import 'package:quizdy/domain/models/ai/ai_file_attachment.dart';
@@ -30,12 +32,8 @@ import 'package:quizdy/domain/repositories/ai_repository.dart';
 /// Handles the Gemini wire format, authentication, rate-limit errors, and
 /// file uploads via the Gemini File API.  Contains no prompt text.
 class GeminiRepository implements AiRepository {
-  static const String _baseUrlBeta =
-      'https://generativelanguage.googleapis.com/v1beta';
   static const String _uploadBaseUrlBeta =
       'https://generativelanguage.googleapis.com/upload/v1beta';
-  static const String _baseUrlAlpha =
-      'https://generativelanguage.googleapis.com/v1alpha';
 
   final Dio _dioClient;
   final ConfigurationService _configurationService;
@@ -58,11 +56,6 @@ class GeminiRepository implements AiRepository {
     final key = await _configurationService.getGeminiApiKey();
     return key != null && key.isNotEmpty;
   }
-
-  // ── URL helpers ──────────────────────────────────────────────────────────
-
-  String _baseUrl() =>
-      modelId == 'gemini-3.1-pro-preview' ? _baseUrlAlpha : _baseUrlBeta;
 
   // ── Error helpers ────────────────────────────────────────────────────────
 
@@ -100,43 +93,6 @@ class GeminiRepository implements AiRepository {
     };
   }
 
-  // ── Shared generation config ─────────────────────────────────────────────
-
-  Map<String, dynamic> _generationConfig({String? responseMimeType}) => {
-    'responseMimeType': ?responseMimeType,
-    'temperature': 0.2,
-    'topK': 5,
-    'topP': 0.95,
-  };
-
-  List<Map<String, dynamic>> get _safetySettings => [
-    {
-      'category': 'HARM_CATEGORY_HARASSMENT',
-      'threshold': 'BLOCK_MEDIUM_AND_ABOVE',
-    },
-    {
-      'category': 'HARM_CATEGORY_HATE_SPEECH',
-      'threshold': 'BLOCK_MEDIUM_AND_ABOVE',
-    },
-    {
-      'category': 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-      'threshold': 'BLOCK_MEDIUM_AND_ABOVE',
-    },
-    {
-      'category': 'HARM_CATEGORY_DANGEROUS_CONTENT',
-      'threshold': 'BLOCK_MEDIUM_AND_ABOVE',
-    },
-  ];
-
-  String _extractText(dynamic jsonResponse, AppLocalizations localizations) {
-    final candidates = jsonResponse['candidates'] as List?;
-    if (candidates != null && candidates.isNotEmpty) {
-      final text = candidates[0]['content']['parts'][0]['text'];
-      return text?.toString().trim() ?? localizations.noResponseReceived;
-    }
-    return localizations.noResponseReceived;
-  }
-
   // ── AiRepository interface ───────────────────────────────────────────────
 
   @override
@@ -150,31 +106,40 @@ class GeminiRepository implements AiRepository {
       throw Exception(localizations.geminiApiKeyNotConfigured);
     }
 
-    final url = '${_baseUrl()}/models/$modelId:generateContent?key=$apiKey';
+    final ai = Genkit(plugins: [googleAI(apiKey: apiKey)]);
 
     try {
-      final response = await _dioClient.post(
-        url,
-        options: Options(headers: {'Content-Type': 'application/json'}),
-        data: {
-          'contents': [
-            {
-              'parts': [
-                {'text': prompt},
-              ],
-            },
+      final response = await ai.generate(
+        model: googleAI.gemini(modelId),
+        prompt: prompt,
+        config: GeminiOptions(
+          temperature: 0.2,
+          topK: 5,
+          topP: 0.95,
+          responseMimeType: responseMimeType,
+          safetySettings: [
+            SafetySettings(
+              category: 'HARM_CATEGORY_HARASSMENT',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+            SafetySettings(
+              category: 'HARM_CATEGORY_HATE_SPEECH',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+            SafetySettings(
+              category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+            SafetySettings(
+              category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
           ],
-          'generationConfig': _generationConfig(
-            responseMimeType: responseMimeType,
-          ),
-          'safetySettings': _safetySettings,
-        },
+        ),
       );
-      return _extractText(response.data, localizations);
-    } on DioException catch (e) {
-      throw _buildException(e, localizations);
-    } catch (_) {
-      throw Exception(localizations.networkErrorGemini);
+      return response.text;
+    } catch (e) {
+      throw Exception('${localizations.networkErrorGemini}: $e');
     }
   }
 
@@ -185,14 +150,58 @@ class GeminiRepository implements AiRepository {
     required AiFileAttachment file,
     String? responseMimeType,
   }) async {
-    final uploadResult = await uploadFile(file, localizations);
-    return sendMessagesWithFileUri(
-      prompt,
-      localizations,
-      fileUri: uploadResult.fileUri,
-      fileMimeType: file.mimeType,
-      responseMimeType: responseMimeType,
-    );
+    final apiKey = await _configurationService.getGeminiApiKey();
+    if (apiKey == null || apiKey.isEmpty) {
+      throw Exception(localizations.geminiApiKeyNotConfigured);
+    }
+
+    final ai = Genkit(plugins: [googleAI(apiKey: apiKey)]);
+    final base64Data = base64Encode(file.bytes);
+    final dataUrl = 'data:${file.mimeType};base64,$base64Data';
+
+    try {
+      final response = await ai.generate(
+        model: googleAI.gemini(modelId),
+        messages: [
+          Message(
+            role: Role.user,
+            content: [
+              MediaPart(
+                media: Media(contentType: file.mimeType, url: dataUrl),
+              ),
+              TextPart(text: prompt),
+            ],
+          ),
+        ],
+        config: GeminiOptions(
+          temperature: 0.2,
+          topK: 5,
+          topP: 0.95,
+          responseMimeType: responseMimeType,
+          safetySettings: [
+            SafetySettings(
+              category: 'HARM_CATEGORY_HARASSMENT',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+            SafetySettings(
+              category: 'HARM_CATEGORY_HATE_SPEECH',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+            SafetySettings(
+              category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+            SafetySettings(
+              category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+          ],
+        ),
+      );
+      return response.text;
+    } catch (e) {
+      throw Exception('${localizations.networkErrorGemini}: $e');
+    }
   }
 
   @override
@@ -264,34 +273,50 @@ class GeminiRepository implements AiRepository {
       throw Exception(localizations.geminiApiKeyNotConfigured);
     }
 
-    final url = '${_baseUrl()}/models/$modelId:generateContent?key=$apiKey';
+    final ai = Genkit(plugins: [googleAI(apiKey: apiKey)]);
 
     try {
-      final response = await _dioClient.post(
-        url,
-        options: Options(headers: {'Content-Type': 'application/json'}),
-        data: {
-          'contents': [
-            {
-              'parts': [
-                {'text': prompt},
-                {
-                  'file_data': {'mime_type': fileMimeType, 'file_uri': fileUri},
-                },
-              ],
-            },
-          ],
-          'generationConfig': _generationConfig(
-            responseMimeType: responseMimeType,
+      final response = await ai.generate(
+        model: googleAI.gemini(modelId),
+        messages: [
+          Message(
+            role: Role.user,
+            content: [
+              MediaPart(
+                media: Media(contentType: fileMimeType, url: fileUri),
+              ),
+              TextPart(text: prompt),
+            ],
           ),
-          'safetySettings': _safetySettings,
-        },
+        ],
+        config: GeminiOptions(
+          temperature: 0.2,
+          topK: 5,
+          topP: 0.95,
+          responseMimeType: responseMimeType,
+          safetySettings: [
+            SafetySettings(
+              category: 'HARM_CATEGORY_HARASSMENT',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+            SafetySettings(
+              category: 'HARM_CATEGORY_HATE_SPEECH',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+            SafetySettings(
+              category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+            SafetySettings(
+              category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+              threshold: 'BLOCK_MEDIUM_AND_ABOVE',
+            ),
+          ],
+        ),
       );
-      return _extractText(response.data, localizations);
-    } on DioException catch (e) {
-      throw _buildException(e, localizations);
-    } catch (_) {
-      throw Exception(localizations.networkErrorGemini);
+      return response.text;
+    } catch (e) {
+      throw Exception('${localizations.networkErrorGemini}: $e');
     }
   }
 }

--- a/lib/data/repositories/ai/openai_repository.dart
+++ b/lib/data/repositories/ai/openai_repository.dart
@@ -13,13 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
+import 'package:genkit/genkit.dart';
+import 'package:genkit_openai/genkit_openai.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/data/services/configuration_service.dart';
 import 'package:quizdy/domain/models/ai/ai_file_attachment.dart';
 import 'package:quizdy/domain/models/ai/ai_file_upload_result.dart';
 import 'package:quizdy/domain/models/ai/ai_model_catalog.dart';
-import 'package:quizdy/domain/models/ai/openai_content_block.dart';
 import 'package:quizdy/domain/repositories/ai_repository.dart';
 
 /// OpenAI implementation of [AiRepository].
@@ -97,36 +100,20 @@ class OpenAiRepository implements AiRepository {
       throw Exception(localizations.openaiApiKeyNotConfigured);
     }
 
-    final data = <String, dynamic>{
-      'model': modelId,
-      'messages': [
-        {'role': 'user', 'content': prompt},
-      ],
-      'max_tokens': 8192,
-      'temperature': 0.2,
-    };
-    if (responseMimeType == 'application/json') {
-      data['response_format'] = {'type': 'json_object'};
-    }
+    final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
 
     try {
-      final response = await _dioClient.post(
-        '$_baseUrl$_chatEndpoint',
-        options: Options(
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer $apiKey',
-          },
+      final response = await ai.generate(
+        model: openAI.model(modelId),
+        prompt: prompt,
+        config: OpenAIChatOptions(
+          temperature: 0.2,
+          jsonMode: responseMimeType == 'application/json',
         ),
-        data: data,
       );
-      final content =
-          response.data['choices'][0]['message']['content'] as String?;
-      return content?.trim() ?? localizations.noResponseReceived;
-    } on DioException catch (e) {
-      throw _buildException(e, localizations);
-    } catch (_) {
-      throw Exception(localizations.networkErrorOpenAI);
+      return response.text;
+    } catch (e) {
+      throw Exception('${localizations.networkErrorOpenAI}: $e');
     }
   }
 
@@ -142,41 +129,32 @@ class OpenAiRepository implements AiRepository {
       throw Exception(localizations.openaiApiKeyNotConfigured);
     }
 
-    final contentBlocks = OpenAIContentBlock.fromPromptAndFile(prompt, file);
-
-    final data = <String, dynamic>{
-      'model': modelId,
-      'messages': [
-        {
-          'role': 'user',
-          'content': contentBlocks.map((b) => b.toJson()).toList(),
-        },
-      ],
-      'max_tokens': 8192,
-      'temperature': 0.2,
-    };
-    if (responseMimeType == 'application/json') {
-      data['response_format'] = {'type': 'json_object'};
-    }
+    final ai = Genkit(plugins: [openAI(apiKey: apiKey)]);
+    final base64Data = base64Encode(file.bytes);
+    final dataUrl = 'data:${file.mimeType};base64,$base64Data';
 
     try {
-      final response = await _dioClient.post(
-        '$_baseUrl$_chatEndpoint',
-        options: Options(
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer $apiKey',
-          },
+      final response = await ai.generate(
+        model: openAI.model(modelId),
+        messages: [
+          Message(
+            role: Role.user,
+            content: [
+              MediaPart(
+                media: Media(contentType: file.mimeType, url: dataUrl),
+              ),
+              TextPart(text: prompt),
+            ],
+          ),
+        ],
+        config: OpenAIChatOptions(
+          temperature: 0.2,
+          jsonMode: responseMimeType == 'application/json',
         ),
-        data: data,
       );
-      final content =
-          response.data['choices'][0]['message']['content'] as String?;
-      return content?.trim() ?? localizations.noResponseReceived;
-    } on DioException catch (e) {
-      throw _buildException(e, localizations);
-    } catch (_) {
-      throw Exception(localizations.networkErrorOpenAI);
+      return response.text;
+    } catch (e) {
+      throw Exception('${localizations.networkErrorOpenAI}: $e');
     }
   }
 

--- a/lib/domain/models/ai/ai_model_catalog.dart
+++ b/lib/domain/models/ai/ai_model_catalog.dart
@@ -13,6 +13,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:quizdy/core/debug_print.dart';
+
 /// A single entry in the AI model catalog.
 class AiModelEntry {
   /// Unique model identifier used in API calls, e.g. `'gpt-4o-mini'`.
@@ -52,7 +57,10 @@ abstract final class AiModelCatalog {
 
   static const String defaultModelId = 'gemini-flash-latest';
 
-  static const List<AiModelEntry> models = [
+  /// Static list of models, initialized with defaults.
+  static List<AiModelEntry> models = List.from(_defaultModels);
+
+  static const List<AiModelEntry> _defaultModels = [
     // ── Google Gemini ─────────────────────────────────────────────────────
     AiModelEntry(
       modelId: 'gemini-flash-latest',
@@ -112,12 +120,18 @@ abstract final class AiModelCatalog {
     ),
   ];
 
-  /// Returns the catalog entry for [modelId], or `null` if not found.
+  /// Returns the catalog entry for [modelId], or a dynamic heuristic entry if not found.
   static AiModelEntry? forModelId(String modelId) {
     for (final entry in models) {
       if (entry.modelId == modelId) return entry;
     }
-    return null;
+    // Heuristic fallback to resolve any custom / un-hardcoded model ID
+    final detectedProvider = _detectProvider(modelId);
+    return AiModelEntry(
+      modelId: modelId,
+      providerId: detectedProvider,
+      displayName: _formatDisplayName(modelId),
+    );
   }
 
   /// Returns all catalog entries that belong to [providerId].
@@ -127,4 +141,94 @@ abstract final class AiModelCatalog {
   /// All models whose provider matches [providerId], in catalog order.
   static List<String> modelIdsForProvider(String providerId) =>
       forProvider(providerId).map((e) => e.modelId).toList();
+
+  /// Dynamically updates the catalog with fetched models.
+  static void updateCatalog(List<AiModelEntry> fetchedModels) {
+    final existingIds = models.map((e) => e.modelId).toSet();
+    final updated = List<AiModelEntry>.from(models);
+    for (final entry in fetchedModels) {
+      if (!existingIds.contains(entry.modelId)) {
+        updated.add(entry);
+        existingIds.add(entry.modelId);
+      }
+    }
+    models = updated;
+  }
+
+  /// Dynamically queries the Genkit registry using the supplied API keys
+  /// and updates the catalog list with any newly discovered models.
+  static Future<void> loadDynamicModels({
+    String? geminiApiKey,
+    String? openaiApiKey,
+  }) async {
+    final plugins = [
+      if (geminiApiKey != null && geminiApiKey.isNotEmpty)
+        googleAI(apiKey: geminiApiKey),
+      if (openaiApiKey != null && openaiApiKey.isNotEmpty)
+        openAI(apiKey: openaiApiKey),
+    ];
+
+    if (plugins.isEmpty) return;
+
+    final ai = Genkit(plugins: plugins);
+    try {
+      final actions = await ai.registry.listActions();
+      final modelActions = actions.where((a) => a.actionType == 'model');
+
+      final List<AiModelEntry> fetchedModels = [];
+      for (final action in modelActions) {
+        if (action.name.startsWith('googleai/')) {
+          final modelId = action.name.replaceFirst('googleai/', '');
+          fetchedModels.add(
+            AiModelEntry(
+              modelId: modelId,
+              providerId: geminiProviderId,
+              displayName: _formatDisplayName(modelId),
+            ),
+          );
+        } else if (action.name.startsWith('openai/')) {
+          final modelId = action.name.replaceFirst('openai/', '');
+          fetchedModels.add(
+            AiModelEntry(
+              modelId: modelId,
+              providerId: openaiProviderId,
+              displayName: _formatDisplayName(modelId),
+            ),
+          );
+        }
+      }
+
+      if (fetchedModels.isNotEmpty) {
+        updateCatalog(fetchedModels);
+      }
+    } catch (e) {
+      // Fail silently and keep current/fallback defaults
+      printInDebug('[AiModelCatalog] Failed to load dynamic models: $e');
+    }
+  }
+
+  static String _detectProvider(String modelId) {
+    final lower = modelId.toLowerCase();
+    if (lower.startsWith('openai/') ||
+        lower.contains('gpt-') ||
+        lower.startsWith('o1') ||
+        lower.startsWith('o3')) {
+      return openaiProviderId;
+    }
+    return geminiProviderId;
+  }
+
+  static String _formatDisplayName(String modelId) {
+    final parts = modelId.split('-');
+    return parts
+        .map((part) {
+          if (part.isEmpty) return '';
+          if (part.toLowerCase() == 'gpt') return 'GPT';
+          if (part.toLowerCase() == 'o1' || part.toLowerCase() == 'o3') {
+            return part;
+          }
+          return part[0].toUpperCase() + part.substring(1);
+        })
+        .join(' ');
+  }
 }

--- a/lib/presentation/widgets/ai_service_model_selector.dart
+++ b/lib/presentation/widgets/ai_service_model_selector.dart
@@ -89,6 +89,12 @@ class _AiServiceModelSelectorState extends State<AiServiceModelSelector> {
       final geminiKey = await configService.getGeminiApiKey();
       final openaiKey = await configService.getOpenAIApiKey();
 
+      // Dynamically load models from Genkit registry using the configured keys
+      await AiModelCatalog.loadDynamicModels(
+        geminiApiKey: geminiKey,
+        openaiApiKey: openaiKey,
+      );
+
       final available = <String>[
         if ((geminiKey?.isNotEmpty ?? false)) AiModelCatalog.geminiProviderId,
         if ((openaiKey?.isNotEmpty ?? false)) AiModelCatalog.openaiProviderId,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "12.1.0"
+  antlr4:
+    dependency: transitive
+    description:
+      name: antlr4
+      sha256: "752b4a6e4ad97953652a2b2bbf5377f46c94b579d3372b50080c7e5858234a05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.2"
   app_links:
     dependency: "direct main"
     description:
@@ -281,6 +289,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.13"
+  decimal:
+    dependency: transitive
+    description:
+      name: decimal
+      sha256: fc706a5618b81e5b367b01dd62621def37abc096f2b46a9bd9068b64c1fa36d0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.4"
   desktop_drop:
     dependency: "direct main"
     description:
@@ -329,6 +345,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  dotprompt:
+    dependency: transitive
+    description:
+      name: dotprompt
+      sha256: d2bc4b143566e424d881db36e6357cbc9140304624c2f8f77d225d783847b4ca
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  email_validator:
+    dependency: transitive
+    description:
+      name: email_validator
+      sha256: b19aa5d92fdd76fbc65112060c94d45ba855105a28bb6e462de7ff03b12fa1fb
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -453,6 +485,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  genkit:
+    dependency: "direct main"
+    description:
+      name: genkit
+      sha256: "31a98b360873f033ceab41921072c2a20eadb621ddc3223851a92f051f2cc0da"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.14.1"
+  genkit_google_genai:
+    dependency: "direct main"
+    description:
+      name: genkit_google_genai
+      sha256: aeb14dd99197267a9d80ff4dc5665200f4ca3f7d1911f554e73bece82f22f62d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.9"
+  genkit_openai:
+    dependency: "direct main"
+    description:
+      name: genkit_openai
+      sha256: "4963c470654d8f055a93139f5faa1144a3f8ad52cc52a7812f08d36293ccdcbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5"
   get_it:
     dependency: "direct main"
     description:
@@ -501,6 +557,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  handlebars_dart:
+    dependency: transitive
+    description:
+      name: handlebars_dart
+      sha256: "016a072264069ff879db1de710f535934dd4526c4770cb592d12b1da79876be9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   hive_ce:
     dependency: "direct main"
     description:
@@ -621,6 +685,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
+  json_schema_builder:
+    dependency: transitive
+    description:
+      name: json_schema_builder
+      sha256: "9c45a80bc25d3b091e96a5a5da49dc7f80d5b0c8496cff60409f9739331ccefb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   leak_tracker:
     dependency: transitive
     description:
@@ -757,6 +829,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
+  openai_dart:
+    dependency: transitive
+    description:
+      name: openai_dart
+      sha256: "96f86ce316c92e5198550168235782ba84695808d85d8b971592c43826d65fba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
+  opentelemetry:
+    dependency: transitive
+    description:
+      name: opentelemetry
+      sha256: "92d63a2e0731d34a7548add82420b8f3819ccda569f9bdfdcc4b25e00fe88da4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.11"
   package_config:
     dependency: transitive
     description:
@@ -941,6 +1029,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  protobuf:
+    dependency: transitive
+    description:
+      name: protobuf
+      sha256: "75ec242d22e950bdcc79ee38dd520ce4ee0bc491d7fadc4ea47694604d22bf06"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   provider:
     dependency: transitive
     description:
@@ -981,6 +1077,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   record_use:
     dependency: transitive
     description:
@@ -997,6 +1109,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  schemantic:
+    dependency: transitive
+    description:
+      name: schemantic
+      sha256: "87c9bb8c2b33be1904533f8f72094e76e772ef227b137dd0b77b4981c5f5ee77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,9 @@ dependencies:
   in_app_update: ^4.2.3
   hive_ce: ^2.19.3
   hive_ce_flutter: ^2.3.4
+  genkit: ^0.14.1
+  genkit_google_genai: ^0.2.9
+  genkit_openai: ^0.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces a major refactor to the AI model integration layer, moving Gemini and OpenAI repositories to use the Genkit plugin system for all AI interactions. It also adds dynamic model discovery: at startup, the app queries the Genkit registry for available models (if API keys are configured) and updates the model catalog accordingly. This enables support for custom and future models without code changes. Several legacy, hardcoded request and parsing methods were removed in favor of the Genkit abstraction.

The most important changes are:

**Genkit Integration & Refactor:**
- Migrated all Gemini and OpenAI API calls in `GeminiRepository` and `OpenAiRepository` to use the Genkit plugin system (`genkit`, `genkit_google_genai`, `genkit_openai`), replacing manual HTTP requests and custom parsing with Genkit’s `generate` method and options objects.

- Removed legacy code for manual HTTP request construction, error handling, and response parsing, as well as hardcoded model lists and helpers, now replaced by Genkit’s abstractions.

**Dynamic Model Catalog:**
- Added dynamic model discovery to `AiModelCatalog`, including methods to update the catalog with models fetched from the Genkit registry at runtime. This enables support for new or custom models without code changes.

- Updated the service locator (`service_locator.dart`) to call `AiModelCatalog.loadDynamicModels` at startup if API keys are present, ensuring the catalog is populated with available models.
**UI Integration:**
- Updated the AI service model selector widget to trigger dynamic model loading from the Genkit registry based on the user’s configured API keys, ensuring the UI reflects all available models.

These changes modernize the AI integration, simplify maintenance, and future-proof the model catalog for new providers and models.