### PR TITLE
feat: add local AI docs and organize Hive storage directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Supported AI providers:
 
 - Google Gemini
 - OpenAI
+- Custom / Local AI (Ollama, LM Studio, Groq, etc. to run models like Gemma 4 or Llama 3 via OpenAI-compatible endpoints)
 
 Supported generation formats:
 
@@ -95,15 +96,20 @@ Supported generation formats:
 git clone https://github.com/vicajilau/quizdy.git
 cd quizdy
 flutter pub get
+dart run build_runner build -d
 flutter run
 ```
 
 ### Optional AI Setup
 
-To enable AI features, configure at least one API key inside the app:
+To enable AI features, configure at least one provider inside the app's settings:
 
-- Gemini API key from [Google AI Studio](https://aistudio.google.com/app/apikey)
-- OpenAI API key from [OpenAI Platform](https://platform.openai.com/api-keys)
+- **Google Gemini**: Get an API key from [Google AI Studio](https://aistudio.google.com/app/apikey).
+- **OpenAI**: Get an API key from [OpenAI Platform](https://platform.openai.com/api-keys).
+- **Custom / Local AI (Ollama, LM Studio, Groq, etc.)**: Run open local models (such as Gemma 4 or Llama 3) or connect to other custom endpoints:
+  - **Base URL**: Set the custom endpoint URL (e.g., `http://localhost:11434/v1` for Ollama or `http://localhost:1234/v1` for LM Studio).
+  - **API Key**: Input your API key if required by the custom provider (otherwise, a dummy key is automatically used).
+  - **Models**: Use the **Load Models** button to dynamically retrieve and register available models from your custom/local endpoint.
 
 ## Development
 

--- a/lib/core/l10n/app_ar.arb
+++ b/lib/core/l10n/app_ar.arb
@@ -782,6 +782,7 @@
   "@getApiKeyTooltip": {
     "description": "Tooltip for the button to get API key from OpenAI"
   },
+  "customAiFileUploadNotSupported": "لا تدعم نماذج الذكاء الاصطناعي المحلية/المخصصة تحميل المستندات.",
   "deleteAction": "حذف",
   "@deleteAction": {
     "description": "Delete action text shown when swiping to delete"

--- a/lib/core/l10n/app_ca.arb
+++ b/lib/core/l10n/app_ca.arb
@@ -801,6 +801,7 @@
   "@getApiKeyTooltip": {
     "description": "Tooltip pel botó per obtenir clau API d'OpenAI"
   },
+  "customAiFileUploadNotSupported": "Els models d'IA locals/personalitzats no admeten la càrrega de documents.",
   "deleteAction": "Eliminar",
   "@deleteAction": {
     "description": "Text d'acció eliminar mostrat en fer lliscar per eliminar"

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -795,6 +795,7 @@
   "@getApiKeyTooltip": {
     "description": "Tooltip für die Schaltfläche zum Erhalten des API-Schlüssels von OpenAI"
   },
+  "customAiFileUploadNotSupported": "Lokale / benutzerdefinierte KI-Modelle unterstützen das Hochladen von Dokumenten nicht.",
   "deleteAction": "Löschen",
   "@deleteAction": {
     "description": "Löschaktions-Text beim Wischen zum Löschen angezeigt"

--- a/lib/core/l10n/app_el.arb
+++ b/lib/core/l10n/app_el.arb
@@ -222,6 +222,7 @@
   "openaiApiKeyDescription": "Απαιτείται για ενσωμάτωση με OpenAI. Το κλειδί OpenAI αποθηκεύεται με ασφάλεια.",
   "aiAssistantRequiresApiKeyError": "Ο Βοηθός Μελέτης AI απαιτεί κλειδί API OpenAI. Παρακαλώ εισάγετε το κλειδί API σας ή απενεργοποιήστε τον Βοηθό AI.",
   "getApiKeyTooltip": "Λήψη κλειδιού API από OpenAI",
+  "customAiFileUploadNotSupported": "Τα τοπικά / προσαρμοσμένα μοντέλα AI δεν υποστηρίζουν τη μεταφόρτωση εγγράφων.",
   "deleteAction": "Διαγραφή",
   "explanationLabel": "Εξήγηση (προαιρετικό)",
   "explanationHint": "Εισάγετε μια εξήγηση για τη/τις σωστή/ές απάντηση/εις",

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -962,6 +962,10 @@
   "@customAiNoModelsError": {
     "description": "Error message when connection succeeded but no models were returned"
   },
+  "customAiFileUploadNotSupported": "Local / Custom AI models do not support document upload.",
+  "@customAiFileUploadNotSupported": {
+    "description": "Warning message displayed when trying to upload a file while using custom / local AI"
+  },
   "deleteAction": "Delete",
   "@deleteAction": {
     "description": "Delete action text shown when swiping to delete"

--- a/lib/core/l10n/app_es.arb
+++ b/lib/core/l10n/app_es.arb
@@ -915,6 +915,10 @@
   "@customAiNoModelsError": {
     "description": "Error message when connection succeeded but no models were returned"
   },
+  "customAiFileUploadNotSupported": "Los modelos de IA locales/personalizados no admiten la carga de documentos.",
+  "@customAiFileUploadNotSupported": {
+    "description": "Warning message displayed when trying to upload a file while using custom / local AI"
+  },
   "deleteAction": "Eliminar",
   "@deleteAction": {
     "description": "Texto de acción eliminar mostrado al deslizar para eliminar"

--- a/lib/core/l10n/app_eu.arb
+++ b/lib/core/l10n/app_eu.arb
@@ -695,6 +695,7 @@
   "@getApiKeyTooltip": {
     "description": "OpenAI API gakoa lortzeko botoiarentzako tooltip-a"
   },
+  "customAiFileUploadNotSupported": "AI lokalek/pertsonalizatuek ez dute dokumenturik kargatzen uzten.",
   "deleteAction": "Ezabatu",
   "@deleteAction": {
     "description": "Ezabatzeko lerratu ekintzan erakusten den ezabatu ekintza testua"

--- a/lib/core/l10n/app_fr.arb
+++ b/lib/core/l10n/app_fr.arb
@@ -701,6 +701,7 @@
   "@getApiKeyTooltip": {
     "description": "Info-bulle pour le bouton d'obtention de clé API depuis OpenAI"
   },
+  "customAiFileUploadNotSupported": "Les modèles d'IA locaux / personnalisés ne prennent pas en charge le chargement de documents.",
   "deleteAction": "Supprimer",
   "@deleteAction": {
     "description": "Texte d'action de suppression affiché lors du glissement pour supprimer"

--- a/lib/core/l10n/app_gl.arb
+++ b/lib/core/l10n/app_gl.arb
@@ -717,6 +717,7 @@
   "@getApiKeyTooltip": {
     "description": "Tooltip para o botón para obter clave API de OpenAI"
   },
+  "customAiFileUploadNotSupported": "Os modelos de IA locais/personalizados no admiten a carga de documentos.",
   "deleteAction": "Eliminar",
   "@deleteAction": {
     "description": "Texto de acción eliminar mostrado ao deslizar para eliminar"

--- a/lib/core/l10n/app_hi.arb
+++ b/lib/core/l10n/app_hi.arb
@@ -673,6 +673,7 @@
   "@getApiKeyTooltip": {
     "description": "Tooltip for the button to get API key from OpenAI"
   },
+  "customAiFileUploadNotSupported": "स्थानीय / कस्टम एआई मॉडल दस्तावेज़ अपलोड का समर्थन नहीं करते हैं।",
   "deleteAction": "हटाएं",
   "@deleteAction": {
     "description": "Delete action text shown when swiping to delete"

--- a/lib/core/l10n/app_it.arb
+++ b/lib/core/l10n/app_it.arb
@@ -700,6 +700,7 @@
   "@getApiKeyTooltip": {
     "description": "Tooltip per il pulsante per ottenere la chiave API da OpenAI"
   },
+  "customAiFileUploadNotSupported": "I modelli IA locali/personalizzati non supportano il caricamento di documenti.",
   "deleteAction": "Elimina",
   "@deleteAction": {
     "description": "Testo azione elimina mostrato quando si scorre per eliminare"

--- a/lib/core/l10n/app_ja.arb
+++ b/lib/core/l10n/app_ja.arb
@@ -681,6 +681,7 @@
   "@getApiKeyTooltip": {
     "description": "OpenAIからAPIキーを取得するボタンのツールチップ"
   },
+  "customAiFileUploadNotSupported": "ローカル/カスタムAIモデルはドキュメントのアップロードをサポートしていません。",
   "deleteAction": "削除",
   "@deleteAction": {
     "description": "スワイプして削除するときに表示されるアクションテキスト"

--- a/lib/core/l10n/app_ka.arb
+++ b/lib/core/l10n/app_ka.arb
@@ -260,6 +260,7 @@
   "openaiApiKeyDescription": "აუცილებელია OpenAI-სთან ინტეგრაციისთვის. თქვენი OpenAI გასაღები დაცულია.",
   "aiAssistantRequiresApiKeyError": "AI სწავლის ასისტენტს სჭირდება OpenAI API Key. შეიყვანეთ თქვენი API გასაღები ან გამორთეთ AI ასისტენტი.",
   "getApiKeyTooltip": "მიიღეთ API Key OpenAI-დან",
+  "customAiFileUploadNotSupported": "ლოკალური / პერსონალური AI მოდელები არ უჭერენ მხარს დოკუმენტების ატვირთვას.",
   "deleteAction": "წაშლა",
   "explanationLabel": "განმარტება (არასავალდებულო)",
   "explanationHint": "შეიყვანეთ განმარტება სწორი პასუხ(ებ)ისთვის",

--- a/lib/core/l10n/app_ko.arb
+++ b/lib/core/l10n/app_ko.arb
@@ -260,6 +260,7 @@
   "openaiApiKeyDescription": "OpenAI 통합을 위해 필요합니다. OpenAI 키는 안전하게 저장됩니다.",
   "aiAssistantRequiresApiKeyError": "AI 학습 어시스턴트를 사용하려면 OpenAI API 키가 필요합니다. API 키를 입력하거나 AI 어시스턴트를 비활성화하십시오.",
   "getApiKeyTooltip": "OpenAI에서 API 키 받기",
+  "customAiFileUploadNotSupported": "로컬 / 사용자 정의 AI 모델은 문서 업로드를 지원하지 않습니다.",
   "deleteAction": "삭제",
   "explanationLabel": "설명 (선택 사항)",
   "explanationHint": "정답에 대한 설명을 입력하세요",

--- a/lib/core/l10n/app_pt.arb
+++ b/lib/core/l10n/app_pt.arb
@@ -687,6 +687,7 @@
   "@getApiKeyTooltip": {
     "description": "Tooltip para o botão para obter chave API do OpenAI"
   },
+  "customAiFileUploadNotSupported": "Os modelos de IA locais/personalizados não suportam o envio de documentos.",
   "deleteAction": "Excluir",
   "@deleteAction": {
     "description": "Texto da ação excluir mostrado ao deslizar para excluir"

--- a/lib/core/l10n/app_ru.arb
+++ b/lib/core/l10n/app_ru.arb
@@ -312,6 +312,7 @@
   "openaiApiKeyDescription": "Требуется для интеграции с OpenAI. Ваш ключ OpenAI хранится в безопасности.",
   "aiAssistantRequiresApiKeyError": "Учебный ассистент ИИ требует API-ключ OpenAI. Пожалуйста, введите ваш API-ключ или отключите ассистента ИИ.",
   "getApiKeyTooltip": "Получить API-ключ в OpenAI",
+  "customAiFileUploadNotSupported": "Локальные / пользовательские модели ИИ не поддерживают загрузку документов.",
   "deleteAction": "Удалить",
   "explanationLabel": "Объяснение (необязательно)",
   "explanationHint": "Введите объяснение правильного ответа(ов)",

--- a/lib/core/l10n/app_uk.arb
+++ b/lib/core/l10n/app_uk.arb
@@ -349,6 +349,7 @@
   "openaiApiKeyDescription": "Необхідно для інтеграції з OpenAI. Ваш ключ OpenAI зберігається в безпеці.",
   "aiAssistantRequiresApiKeyError": "Навчальний асистент ШІ потребує API-ключ OpenAI. Будь ласка, введіть свій API-ключ або вимкніть асистента ШІ.",
   "getApiKeyTooltip": "Отримати API-ключ у OpenAI",
+  "customAiFileUploadNotSupported": "Локальні / власні моделі ШІ не підтримують завантаження документів.",
   "deleteAction": "Видалити",
   "explanationLabel": "Пояснення (необов'язково)",
   "explanationHint": "Введіть пояснення правильної відповіді (відповідей)",

--- a/lib/core/l10n/app_zh.arb
+++ b/lib/core/l10n/app_zh.arb
@@ -665,6 +665,7 @@
   "@getApiKeyTooltip": {
     "description": "Tooltip for the button to get API key from OpenAI"
   },
+  "customAiFileUploadNotSupported": "本地/自定义 AI 模型不支持上传文档。",
   "deleteAction": "删除",
   "@deleteAction": {
     "description": "Delete action text shown when swiping to delete"

--- a/lib/data/services/database_service.dart
+++ b/lib/data/services/database_service.dart
@@ -26,7 +26,7 @@ class DatabaseService {
     if (path != null) {
       Hive.init(path);
     } else {
-      await Hive.initFlutter();
+      await Hive.initFlutter('quizdy');
     }
 
     // Register all custom adapters

--- a/lib/presentation/screens/dialogs/widgets/ai_generate_step2_widget.dart
+++ b/lib/presentation/screens/dialogs/widgets/ai_generate_step2_widget.dart
@@ -19,6 +19,7 @@ import 'package:go_router/go_router.dart';
 import 'package:flutter_lucide/flutter_lucide.dart';
 import 'package:mime/mime.dart';
 import 'package:quizdy/domain/models/ai/ai_file_attachment.dart';
+import 'package:quizdy/domain/models/ai/ai_model_catalog.dart';
 import 'package:quizdy/core/l10n/app_localizations.dart';
 import 'package:quizdy/core/theme/app_theme.dart';
 import 'package:quizdy/core/theme/extensions/confirm_dialog_colors_extension.dart';
@@ -179,6 +180,13 @@ class _AiGenerateStep2WidgetState extends State<AiGenerateStep2Widget> {
   }
 
   Future<void> _handleDroppedFile(DropDoneDetails details) async {
+    final modelEntry = widget.selectedModel != null
+        ? AiModelCatalog.forModelId(widget.selectedModel!)
+        : null;
+    final isCustomAi =
+        modelEntry?.providerId == AiModelCatalog.customProviderId;
+    if (isCustomAi) return;
+
     if (details.files.isEmpty) return;
     final file = details.files.first;
     final bytes = await file.readAsBytes();
@@ -197,6 +205,12 @@ class _AiGenerateStep2WidgetState extends State<AiGenerateStep2Widget> {
   }
 
   bool _isGenerateEnabled() {
+    final modelEntry = widget.selectedModel != null
+        ? AiModelCatalog.forModelId(widget.selectedModel!)
+        : null;
+    final isCustomAi =
+        modelEntry?.providerId == AiModelCatalog.customProviderId;
+
     if (_componentTypeSelectorEnabled && _selectedComponentTypes.isEmpty) {
       return false;
     }
@@ -205,6 +219,9 @@ class _AiGenerateStep2WidgetState extends State<AiGenerateStep2Widget> {
     }
     if (_chunkSelectorEnabled) {
       return _selectedChunkIndices.isNotEmpty;
+    }
+    if (isCustomAi) {
+      return widget.textController.text.isNotEmpty;
     }
     return widget.textController.text.isNotEmpty ||
         widget.fileAttachment != null;
@@ -216,6 +233,12 @@ class _AiGenerateStep2WidgetState extends State<AiGenerateStep2Widget> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final colors = context.appColors;
     final borderColor = isDark ? Colors.transparent : AppTheme.borderColor;
+
+    final modelEntry = widget.selectedModel != null
+        ? AiModelCatalog.forModelId(widget.selectedModel!)
+        : null;
+    final isCustomAi =
+        modelEntry?.providerId == AiModelCatalog.customProviderId;
 
     return DialogDropZone(
       onFilesDropped: _handleDroppedFile,
@@ -391,8 +414,9 @@ class _AiGenerateStep2WidgetState extends State<AiGenerateStep2Widget> {
                               widget.onAutoDifficultyChanged,
                           fileAttachment: widget.fileAttachment,
                           isDragging: _isDragging,
+                          isDisabled: isCustomAi,
                         ),
-                        if (widget.fileAttachment == null) ...[
+                        if (widget.fileAttachment == null && !isCustomAi) ...[
                           const SizedBox(height: 8),
                           QuizdyButton(
                             type: QuizdyButtonType.secondary,

--- a/lib/presentation/widgets/components/ai_file_upload_zone.dart
+++ b/lib/presentation/widgets/components/ai_file_upload_zone.dart
@@ -25,6 +25,8 @@ class AiFileUploadZone extends StatelessWidget {
   final ValueChanged<bool> onAutoDifficultyChanged;
   final AiFileAttachment? fileAttachment;
   final bool isDragging;
+  final bool isDisabled;
+  final String? disabledMessage;
 
   const AiFileUploadZone({
     super.key,
@@ -33,6 +35,8 @@ class AiFileUploadZone extends StatelessWidget {
     required this.onAutoDifficultyChanged,
     this.fileAttachment,
     this.isDragging = false,
+    this.isDisabled = false,
+    this.disabledMessage,
   });
 
   @override
@@ -45,17 +49,23 @@ class AiFileUploadZone extends StatelessWidget {
         : const Color(0xFFD4D4D8);
 
     return GestureDetector(
-      onTap: onPickFile,
+      onTap: isDisabled ? null : onPickFile,
       child: Container(
         height: 64,
         width: double.infinity,
         decoration: BoxDecoration(
-          color: isDragging
-              ? Theme.of(context).primaryColor.withValues(alpha: 0.05)
-              : Colors.transparent,
+          color: isDisabled
+              ? (isDark
+                    ? Colors.white.withValues(alpha: 0.02)
+                    : Colors.black.withValues(alpha: 0.02))
+              : (isDragging
+                    ? Theme.of(context).primaryColor.withValues(alpha: 0.05)
+                    : Colors.transparent),
           borderRadius: BorderRadius.circular(12),
           border: Border.all(
-            color: isDragging ? Theme.of(context).primaryColor : attachStroke,
+            color: isDisabled
+                ? attachStroke.withValues(alpha: 0.5)
+                : (isDragging ? Theme.of(context).primaryColor : attachStroke),
             width: 2,
           ),
         ),
@@ -68,14 +78,31 @@ class AiFileUploadZone extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Icon(
-                  isDragging ? LucideIcons.download : LucideIcons.paperclip,
-                  color: isDragging
-                      ? Theme.of(context).primaryColor
-                      : colors.subtitle,
+                  isDisabled
+                      ? LucideIcons.triangle_alert
+                      : (isDragging
+                            ? LucideIcons.download
+                            : LucideIcons.paperclip),
+                  color: isDisabled
+                      ? colors.subtitle.withValues(alpha: 0.4)
+                      : (isDragging
+                            ? Theme.of(context).primaryColor
+                            : colors.subtitle),
                   size: 20,
                 ),
                 const SizedBox(width: 12),
-                if (isDragging)
+                if (isDisabled)
+                  Text(
+                    disabledMessage ??
+                        localizations.customAiFileUploadNotSupported,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                      color: colors.subtitle.withValues(alpha: 0.5),
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  )
+                else if (isDragging)
                   Text(
                     localizations.dropAttachmentHere,
                     style: TextStyle(
@@ -105,7 +132,7 @@ class AiFileUploadZone extends StatelessWidget {
                     ),
                     overflow: TextOverflow.ellipsis,
                   ),
-                if (fileAttachment != null && !isDragging)
+                if (fileAttachment != null && !isDragging && !isDisabled)
                   Padding(
                     padding: const EdgeInsets.only(left: 12.0, right: 16.0),
                     child: GestureDetector(


### PR DESCRIPTION
## Summary
- **Local / Custom AI Support**: Updated the \README.md\ to document the newly added Support for Local / Custom AI providers (like Ollama, LM Studio, Groq, etc.). Explicitly highlighted support for running open models like Gemma 4 and Llama 3, along with configuration steps for endpoints, custom API keys, and dynamic model fetching.
- **Hive Database Clean-up**: Modified the initialization of Hive in \DatabaseService\ to save storage files (\srs_metadata_box.hive\, \srs_metadata_box.lock\) under a dedicated \quizdy\ subdirectory (\Hive.initFlutter('quizdy')\) instead of directly in the root of the user's Documents directory.